### PR TITLE
feat(PBI-31): Direct messaging backend for PI-Student communication

### DIFF
--- a/server/dist/index.js
+++ b/server/dist/index.js
@@ -1,4 +1,4 @@
-import 'dotenv/config';
+import { config } from './config/env.js';
 import express from 'express';
 import cors from 'cors';
 import authRoutes from './routes/auth.js';
@@ -6,18 +6,30 @@ import studentRoutes from './routes/students.js';
 import piRoutes from './routes/pis.js';
 import positionRoutes from './routes/positions.js';
 import applicationRoutes from './routes/applications.js';
+import participantRoutes from './routes/participants.js';
+import studiesRoutes from './routes/studies.js';
+import messageRoutes from './routes/messages.js';
 const app = express();
-const PORT = process.env.PORT || 3000;
-app.use(cors());
+app.use(cors({ origin: config.clientUrl, credentials: true }));
 app.use(express.json());
 app.use('/api/auth', authRoutes);
 app.use('/api/students', studentRoutes);
 app.use('/api/pis', piRoutes);
 app.use('/api/positions', positionRoutes);
 app.use('/api/applications', applicationRoutes);
+app.use('/api/participants', participantRoutes);
+app.use('/api/studies', studiesRoutes);
+app.use('/api/messages', messageRoutes);
 app.get('/api/health', (_req, res) => {
-    res.json({ ok: true });
+    res.json({ ok: true, timestamp: new Date().toISOString() });
 });
-app.listen(PORT, () => {
-    console.log(`ResearchHub server running on http://localhost:${PORT}`);
+// Global error handler — catches unhandled errors from async route handlers
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+app.use((err, _req, res, _next) => {
+    console.error('[Error]', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+});
+app.listen(config.port, () => {
+    console.log(`ResearchHub server running on http://localhost:${config.port}`);
+    console.log(`Environment: ${config.nodeEnv}`);
 });

--- a/server/dist/routes/messages.js
+++ b/server/dist/routes/messages.js
@@ -1,0 +1,135 @@
+import { Router } from 'express';
+import pool from '../db/pool.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { asyncHandler } from '../lib/asyncHandler.js';
+const router = Router();
+// POST /api/messages - send a message (creates conversation if needed)
+router.post('/', authMiddleware, asyncHandler(async (req, res) => {
+    const { recipientId, body } = req.body;
+    if (!recipientId || !body) {
+        return res.status(400).json({ error: 'recipientId and body are required' });
+    }
+    if (!body.trim()) {
+        return res.status(400).json({ error: 'Message body cannot be empty' });
+    }
+    // Find existing conversation between these two users
+    const existingConv = await pool.query(`SELECT c.id FROM conversations c
+     JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.user_id = $1
+     JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp2.user_id = $2
+     GROUP BY c.id
+     HAVING COUNT(*) = 2`, [req.userId, recipientId]);
+    let conversationId;
+    if (existingConv.rows.length > 0) {
+        conversationId = existingConv.rows[0].id;
+    }
+    else {
+        // Create new conversation
+        const newConv = await pool.query('INSERT INTO conversations DEFAULT VALUES RETURNING id');
+        conversationId = newConv.rows[0].id;
+        // Add both participants
+        await pool.query('INSERT INTO conversation_participants (conversation_id, user_id) VALUES ($1, $2), ($1, $3)', [conversationId, req.userId, recipientId]);
+    }
+    // Insert message
+    const messageResult = await pool.query(`INSERT INTO messages (conversation_id, sender_id, body)
+     VALUES ($1, $2, $3)
+     RETURNING *`, [conversationId, req.userId, body.trim()]);
+    const row = messageResult.rows[0];
+    return res.status(201).json({
+        id: row.id,
+        conversationId: row.conversation_id,
+        senderId: row.sender_id,
+        body: row.body,
+        readAt: row.read_at,
+        createdAt: row.created_at,
+    });
+}));
+// GET /api/messages/conversations - list all conversations for current user
+router.get('/conversations', authMiddleware, asyncHandler(async (req, res) => {
+    const result = await pool.query(`SELECT c.*,
+            (SELECT body FROM messages WHERE conversation_id = c.id ORDER BY created_at DESC LIMIT 1) as last_message,
+            (SELECT created_at FROM messages WHERE conversation_id = c.id ORDER BY created_at DESC LIMIT 1) as last_message_at,
+            (SELECT COUNT(*) FROM messages WHERE conversation_id = c.id AND sender_id != $1 AND read_at IS NULL) as unread_count
+     FROM conversations c
+     JOIN conversation_participants cp ON cp.conversation_id = c.id
+     WHERE cp.user_id = $1
+     ORDER BY last_message_at DESC NULLS LAST`, [req.userId]);
+    // Get other participant info for each conversation
+    const conversations = await Promise.all(result.rows.map(async (conv) => {
+        const participants = await pool.query(`SELECT u.id, u.first_name, u.last_name, u.email, u.role
+       FROM conversation_participants cp
+       JOIN users u ON u.id = cp.user_id
+       WHERE cp.conversation_id = $1 AND cp.user_id != $2`, [conv.id, req.userId]);
+        return {
+            id: conv.id,
+            lastMessage: conv.last_message,
+            lastMessageAt: conv.last_message_at,
+            unreadCount: parseInt(conv.unread_count, 10),
+            otherParticipant: participants.rows[0] || null,
+            createdAt: conv.created_at,
+            updatedAt: conv.updated_at,
+        };
+    }));
+    return res.json(conversations);
+}));
+// GET /api/messages/conversations/:id - get messages in a conversation
+router.get('/conversations/:id', authMiddleware, asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    // Verify user is participant
+    const participant = await pool.query('SELECT 1 FROM conversation_participants WHERE conversation_id = $1 AND user_id = $2', [id, req.userId]);
+    if (participant.rows.length === 0) {
+        return res.status(403).json({ error: 'Not a participant of this conversation' });
+    }
+    const result = await pool.query(`SELECT m.*, u.first_name, u.last_name, u.role as sender_role
+     FROM messages m
+     JOIN users u ON u.id = m.sender_id
+     WHERE m.conversation_id = $1
+     ORDER BY m.created_at ASC`, [id]);
+    return res.json(result.rows.map((row) => ({
+        id: row.id,
+        conversationId: row.conversation_id,
+        senderId: row.sender_id,
+        body: row.body,
+        readAt: row.read_at,
+        createdAt: row.created_at,
+        senderFirstName: row.first_name,
+        senderLastName: row.last_name,
+        senderRole: row.sender_role,
+    })));
+}));
+// PATCH /api/messages/:id/read - mark a message as read
+router.patch('/:id/read', authMiddleware, asyncHandler(async (req, res) => {
+    const { id } = req.params;
+    // Verify user is participant of the conversation
+    const message = await pool.query(`SELECT m.id, m.conversation_id, m.sender_id
+     FROM messages m
+     JOIN conversation_participants cp ON cp.conversation_id = m.conversation_id
+     WHERE m.id = $1 AND cp.user_id = $2`, [id, req.userId]);
+    if (message.rows.length === 0) {
+        return res.status(404).json({ error: 'Message not found or access denied' });
+    }
+    const result = await pool.query(`UPDATE messages SET read_at = NOW()
+     WHERE id = $1 AND read_at IS NULL
+     RETURNING *`, [id]);
+    if (result.rows.length === 0) {
+        // Already read or not found
+        const existing = await pool.query('SELECT * FROM messages WHERE id = $1', [id]);
+        return res.json({
+            id: existing.rows[0].id,
+            conversationId: existing.rows[0].conversation_id,
+            senderId: existing.rows[0].sender_id,
+            body: existing.rows[0].body,
+            readAt: existing.rows[0].read_at,
+            createdAt: existing.rows[0].created_at,
+        });
+    }
+    const row = result.rows[0];
+    return res.json({
+        id: row.id,
+        conversationId: row.conversation_id,
+        senderId: row.sender_id,
+        body: row.body,
+        readAt: row.read_at,
+        createdAt: row.created_at,
+    });
+}));
+export default router;

--- a/server/src/db/migrations/004_direct_messaging.sql
+++ b/server/src/db/migrations/004_direct_messaging.sql
@@ -1,0 +1,90 @@
+-- Migration 004: Direct messaging system
+-- Creates conversations and messages tables for PI-Student messaging
+
+-- Table: conversations
+-- Stores a conversation between two or more participants
+create table if not exists conversations (
+  id            uuid primary key default gen_random_uuid(),
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+-- Table: conversation_participants
+-- Links users to conversations (many-to-many)
+create table if not exists conversation_participants (
+  conversation_id uuid not null references conversations (id) on delete cascade,
+  user_id         uuid not null references users (id) on delete cascade,
+  joined_at       timestamptz not null default now(),
+  primary key (conversation_id, user_id)
+);
+
+-- Table: messages
+-- Individual messages within a conversation
+create table if not exists messages (
+  id              uuid primary key default gen_random_uuid(),
+  conversation_id uuid not null references conversations (id) on delete cascade,
+  sender_id       uuid not null references users (id) on delete cascade,
+  body            text not null,
+  read_at         timestamptz,
+  created_at      timestamptz not null default now()
+);
+
+-- Indexes for performance
+create index if not exists conversation_participants_user_id_idx on conversation_participants (user_id);
+create index if not exists messages_conversation_id_idx on messages (conversation_id);
+create index if not exists messages_sender_id_idx on messages (sender_id);
+create index if not exists messages_created_at_idx on messages (created_at);
+
+-- Updated_at trigger for conversations
+create or replace function set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create or replace trigger trg_conversations_updated_at
+  before update on conversations for each row execute function set_updated_at();
+
+create or replace trigger trg_messages_updated_at
+  before update on messages for each row execute function set_updated_at();
+
+-- Row Level Security
+alter table conversations enable row level security;
+alter table conversation_participants enable row level security;
+alter table messages enable row level security;
+
+-- Users can access conversations they are participants of
+create policy "Users can view their conversations"
+  on conversations for select
+  using (
+    id in (
+      select conversation_id from conversation_participants where user_id = auth.uid()
+    )
+  );
+
+create policy "Users can create conversations"
+  on conversations for insert
+  with check (
+    id in (
+      select conversation_id from conversation_participants where user_id = auth.uid()
+    )
+  );
+
+-- Users can view messages in their conversations
+create policy "Users can view messages in their conversations"
+  on messages for select
+  using (
+    conversation_id in (
+      select conversation_id from conversation_participants where user_id = auth.uid()
+    )
+  );
+
+create policy "Users can send messages to their conversations"
+  on messages for insert
+  with check (
+    conversation_id in (
+      select conversation_id from conversation_participants where user_id = auth.uid()
+    )
+  );

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,6 +8,7 @@ import positionRoutes from './routes/positions.js';
 import applicationRoutes from './routes/applications.js';
 import participantRoutes from './routes/participants.js';
 import studiesRoutes from './routes/studies.js';
+import messageRoutes from './routes/messages.js';
 
 const app = express();
 
@@ -21,6 +22,7 @@ app.use('/api/positions', positionRoutes);
 app.use('/api/applications', applicationRoutes);
 app.use('/api/participants', participantRoutes);
 app.use('/api/studies', studiesRoutes);
+app.use('/api/messages', messageRoutes);
 
 app.get('/api/health', (_req, res) => {
   res.json({ ok: true, timestamp: new Date().toISOString() });

--- a/server/src/routes/messages.ts
+++ b/server/src/routes/messages.ts
@@ -1,0 +1,186 @@
+import { Router, Request, Response } from 'express';
+import pool from '../db/pool.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { asyncHandler } from '../lib/asyncHandler.js';
+
+const router = Router();
+
+// POST /api/messages - send a message (creates conversation if needed)
+router.post('/', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
+  const { recipientId, body } = req.body;
+  if (!recipientId || !body) {
+    return res.status(400).json({ error: 'recipientId and body are required' });
+  }
+  if (!body.trim()) {
+    return res.status(400).json({ error: 'Message body cannot be empty' });
+  }
+
+  // Find existing conversation between these two users
+  const existingConv = await pool.query(
+    `SELECT c.id FROM conversations c
+     JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.user_id = $1
+     JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp2.user_id = $2
+     GROUP BY c.id
+     HAVING COUNT(*) = 2`,
+    [req.userId, recipientId]
+  );
+
+  let conversationId;
+  if (existingConv.rows.length > 0) {
+    conversationId = existingConv.rows[0].id;
+  } else {
+    // Create new conversation
+    const newConv = await pool.query(
+      'INSERT INTO conversations DEFAULT VALUES RETURNING id'
+    );
+    conversationId = newConv.rows[0].id;
+
+    // Add both participants
+    await pool.query(
+      'INSERT INTO conversation_participants (conversation_id, user_id) VALUES ($1, $2), ($1, $3)',
+      [conversationId, req.userId, recipientId]
+    );
+  }
+
+  // Insert message
+  const messageResult = await pool.query(
+    `INSERT INTO messages (conversation_id, sender_id, body)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [conversationId, req.userId, body.trim()]
+  );
+
+  const row = messageResult.rows[0];
+  return res.status(201).json({
+    id: row.id,
+    conversationId: row.conversation_id,
+    senderId: row.sender_id,
+    body: row.body,
+    readAt: row.read_at,
+    createdAt: row.created_at,
+  });
+}));
+
+// GET /api/messages/conversations - list all conversations for current user
+router.get('/conversations', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
+  const result = await pool.query(
+    `SELECT c.*,
+            (SELECT body FROM messages WHERE conversation_id = c.id ORDER BY created_at DESC LIMIT 1) as last_message,
+            (SELECT created_at FROM messages WHERE conversation_id = c.id ORDER BY created_at DESC LIMIT 1) as last_message_at,
+            (SELECT COUNT(*) FROM messages WHERE conversation_id = c.id AND sender_id != $1 AND read_at IS NULL) as unread_count
+     FROM conversations c
+     JOIN conversation_participants cp ON cp.conversation_id = c.id
+     WHERE cp.user_id = $1
+     ORDER BY last_message_at DESC NULLS LAST`,
+    [req.userId]
+  );
+
+  // Get other participant info for each conversation
+  const conversations = await Promise.all(result.rows.map(async (conv) => {
+    const participants = await pool.query(
+      `SELECT u.id, u.first_name, u.last_name, u.email, u.role
+       FROM conversation_participants cp
+       JOIN users u ON u.id = cp.user_id
+       WHERE cp.conversation_id = $1 AND cp.user_id != $2`,
+      [conv.id, req.userId]
+    );
+    return {
+      id: conv.id,
+      lastMessage: conv.last_message,
+      lastMessageAt: conv.last_message_at,
+      unreadCount: parseInt(conv.unread_count, 10),
+      otherParticipant: participants.rows[0] || null,
+      createdAt: conv.created_at,
+      updatedAt: conv.updated_at,
+    };
+  }));
+
+  return res.json(conversations);
+}));
+
+// GET /api/messages/conversations/:id - get messages in a conversation
+router.get('/conversations/:id', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
+  const { id } = req.params;
+
+  // Verify user is participant
+  const participant = await pool.query(
+    'SELECT 1 FROM conversation_participants WHERE conversation_id = $1 AND user_id = $2',
+    [id, req.userId]
+  );
+  if (participant.rows.length === 0) {
+    return res.status(403).json({ error: 'Not a participant of this conversation' });
+  }
+
+  const result = await pool.query(
+    `SELECT m.*, u.first_name, u.last_name, u.role as sender_role
+     FROM messages m
+     JOIN users u ON u.id = m.sender_id
+     WHERE m.conversation_id = $1
+     ORDER BY m.created_at ASC`,
+    [id]
+  );
+
+  return res.json(
+    result.rows.map((row) => ({
+      id: row.id,
+      conversationId: row.conversation_id,
+      senderId: row.sender_id,
+      body: row.body,
+      readAt: row.read_at,
+      createdAt: row.created_at,
+      senderFirstName: row.first_name,
+      senderLastName: row.last_name,
+      senderRole: row.sender_role,
+    }))
+  );
+}));
+
+// PATCH /api/messages/:id/read - mark a message as read
+router.patch('/:id/read', authMiddleware, asyncHandler(async (req: Request, res: Response) => {
+  const { id } = req.params;
+
+  // Verify user is participant of the conversation
+  const message = await pool.query(
+    `SELECT m.id, m.conversation_id, m.sender_id
+     FROM messages m
+     JOIN conversation_participants cp ON cp.conversation_id = m.conversation_id
+     WHERE m.id = $1 AND cp.user_id = $2`,
+    [id, req.userId]
+  );
+
+  if (message.rows.length === 0) {
+    return res.status(404).json({ error: 'Message not found or access denied' });
+  }
+
+  const result = await pool.query(
+    `UPDATE messages SET read_at = NOW()
+     WHERE id = $1 AND read_at IS NULL
+     RETURNING *`,
+    [id]
+  );
+
+  if (result.rows.length === 0) {
+    // Already read or not found
+    const existing = await pool.query('SELECT * FROM messages WHERE id = $1', [id]);
+    return res.json({
+      id: existing.rows[0].id,
+      conversationId: existing.rows[0].conversation_id,
+      senderId: existing.rows[0].sender_id,
+      body: existing.rows[0].body,
+      readAt: existing.rows[0].read_at,
+      createdAt: existing.rows[0].created_at,
+    });
+  }
+
+  const row = result.rows[0];
+  return res.json({
+    id: row.id,
+    conversationId: row.conversation_id,
+    senderId: row.sender_id,
+    body: row.body,
+    readAt: row.read_at,
+    createdAt: row.created_at,
+  });
+}));
+
+export default router;


### PR DESCRIPTION
## Summary
- Add conversations table (id, created_at, updated_at)
- Add conversation_participants junction table (conversation_id, user_id, joined_at)
- Add messages table (id, conversation_id, sender_id, body, read_at, created_at)
- Add indexes on conversation_id, sender_id, and created_at for performance

## API Endpoints
- POST /api/messages — send a message, creates conversation if needed
- GET /api/messages/conversations — list all conversations with last message preview
- GET /api/messages/conversations/:id — get messages in a conversation
- PATCH /api/messages/:id/read — mark a message as read

## Test plan
- [ ] Send a message from PI to student — verify conversation created
- [ ] List conversations — verify shows other participant info and last message
- [ ] Get messages in conversation — verify correct ordering
- [ ] Mark message as read — verify read_at timestamp set
- [ ] Reply to conversation — verify existing conversation used