### PR TITLE
Student settings page; read-only submitted applications

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { Login } from './pages/auth/Login';
 import { Register } from './pages/auth/Register';
 import { StudentDashboard } from './pages/student/StudentDashboard';
 import { StudentProfile } from './pages/student/StudentProfile';
+import { StudentSettings } from './pages/student/StudentSettings';
 import { PositionList } from './pages/student/PositionList';
 import { PositionDetail } from './pages/student/PositionDetail';
 import { StudentApplications } from './pages/student/StudentApplications';
@@ -38,7 +39,7 @@ function App() {
           >
             <Route path="dashboard" element={<StudentDashboard />} />
             <Route path="profile" element={<StudentProfile />} />
-            <Route path="settings" element={<StudentProfile />} />
+            <Route path="settings" element={<StudentSettings />} />
             <Route path="positions" element={<PositionList />} />
             <Route path="positions/:id" element={<PositionDetail />} />
             <Route path="applications" element={<StudentApplications />} />

--- a/client/src/components/ApplicationQuestionsEditor.tsx
+++ b/client/src/components/ApplicationQuestionsEditor.tsx
@@ -1,0 +1,115 @@
+import type { ApplicationQuestion, ApplicationQuestionType } from '../types/applicationQuestions';
+
+const TYPES: { value: ApplicationQuestionType; label: string }[] = [
+  { value: 'text', label: 'Text' },
+  { value: 'number', label: 'Number' },
+  { value: 'dropdown', label: 'Dropdown' },
+  { value: 'choice', label: 'Multiple choice (one)' },
+];
+
+function newQuestion(): ApplicationQuestion {
+  return {
+    id: crypto.randomUUID(),
+    type: 'text',
+    label: '',
+    required: false,
+  };
+}
+
+interface Props {
+  value: ApplicationQuestion[];
+  onChange: (q: ApplicationQuestion[]) => void;
+}
+
+export function ApplicationQuestionsEditor({ value, onChange }: Props) {
+  const updateAt = (index: number, patch: Partial<ApplicationQuestion>) => {
+    const next = value.map((q, i) => (i === index ? { ...q, ...patch } : q));
+    const merged = next[index];
+    if (merged && (patch.type === 'text' || patch.type === 'number')) {
+      next[index] = { ...merged, options: undefined };
+    }
+    onChange(next);
+  };
+
+  const setOptionsFromText = (index: number, text: string) => {
+    const options = text
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    updateAt(index, { options });
+  };
+
+  return (
+    <div className="space-y-4 border border-slate-200 rounded-lg p-4 bg-slate-50/50">
+      <div>
+        <h2 className="text-lg font-semibold text-inherit">Application questions</h2>
+        <p className="text-sm text-slate-600 mt-1">
+          Optional extra questions students answer when they apply. Dropdown and multiple choice need one option per line.
+        </p>
+      </div>
+      {value.map((q, index) => (
+        <div key={q.id} className="p-3 border border-slate-200 rounded-lg bg-white space-y-2">
+          <div className="flex flex-wrap gap-2 items-end">
+            <div className="flex-1 min-w-[140px]">
+              <label className="block text-xs font-medium text-slate-600 mb-0.5">Type</label>
+              <select
+                value={q.type}
+                onChange={(e) => updateAt(index, { type: e.target.value as ApplicationQuestionType })}
+                className="w-full px-2 py-1.5 border border-slate-300 rounded text-sm"
+              >
+                {TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1 min-w-[180px]">
+              <label className="block text-xs font-medium text-slate-600 mb-0.5">Label</label>
+              <input
+                type="text"
+                value={q.label}
+                onChange={(e) => updateAt(index, { label: e.target.value })}
+                placeholder="Question text"
+                className="w-full px-2 py-1.5 border border-slate-300 rounded text-sm"
+              />
+            </div>
+            <label className="flex items-center gap-1.5 text-sm pb-1">
+              <input
+                type="checkbox"
+                checked={!!q.required}
+                onChange={(e) => updateAt(index, { required: e.target.checked })}
+              />
+              Required
+            </label>
+            <button
+              type="button"
+              onClick={() => onChange(value.filter((_, i) => i !== index))}
+              className="text-sm text-red-600 hover:underline pb-1"
+            >
+              Remove
+            </button>
+          </div>
+          {(q.type === 'dropdown' || q.type === 'choice') && (
+            <div>
+              <label className="block text-xs font-medium text-slate-600 mb-0.5">Options (one per line)</label>
+              <textarea
+                value={(q.options || []).join('\n')}
+                onChange={(e) => setOptionsFromText(index, e.target.value)}
+                rows={3}
+                className="w-full px-2 py-1.5 border border-slate-300 rounded text-sm font-mono"
+              />
+            </div>
+          )}
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={() => onChange([...value, newQuestion()])}
+        className="text-sm font-medium text-teal-700 hover:underline"
+      >
+        + Add question
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/ui/network-background.tsx
+++ b/client/src/components/ui/network-background.tsx
@@ -26,7 +26,7 @@ interface Pulse {
   speed: number;
 }
 
-// ── COLOR PALETTE — CMYK blue 100 60 0 20 → RGB(0,82,204) + variants ───
+// Color palette: CMYK blue 100 60 0 20 to RGB(0,82,204) and variants
 const COLORS = {
   student: { r: 0, g: 82, b: 204 },
   lab: { r: 40, g: 110, b: 220 },

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { User, StudentProfile, PIProfile, Position, Application, LabRosterMember } from '../types';
+import type { User, StudentProfile, PIProfile, Position, Application, LabRosterMember, QuestionAnswersMap } from '../types';
 
 const API_BASE = '/api';
 
@@ -84,7 +84,7 @@ export const api = {
     recommended: () => request<Position[]>('/positions/recommended'),
   },
   applications: {
-    create: (body: { positionId: string; coverLetter?: string }) =>
+    create: (body: { positionId: string; coverLetter?: string; questionAnswers?: QuestionAnswersMap }) =>
       request<Application>('/applications', { method: 'POST', body: JSON.stringify(body) }),
     mine: () =>
       request<(Application & { positionTitle?: string; labName?: string; department?: string | null })[]>('/applications/mine'),

--- a/client/src/pages/auth/Landing.tsx
+++ b/client/src/pages/auth/Landing.tsx
@@ -13,7 +13,7 @@ export function Landing() {
       {/* Network Background - nodes, connections, pulses */}
       <NetworkBackground />
 
-      {/* Content — full width + centered stack (avoids drift from body sidebar padding) */}
+      {/* Content: full width + centered stack (avoids drift from body sidebar padding) */}
       <div className="relative z-[150] flex w-full flex-1 flex-col items-center justify-center px-4 pb-24 text-center sm:pb-0">
         <div className="flex w-full max-w-5xl flex-col items-center justify-center">
         <h1 className="mb-8 w-full max-w-5xl text-5xl font-bold text-[#0052CC] md:text-8xl">

--- a/client/src/pages/pi/LabRoster.tsx
+++ b/client/src/pages/pi/LabRoster.tsx
@@ -75,7 +75,7 @@ export function LabRoster() {
             <header className="bs-header">
               <h1 className="bs-title">Lab roster</h1>
               <p className="bs-subtitle">
-                Students you have accepted for your research positions — your active lab members. For everyone on the
+                Students you have accepted for your research positions: your active lab members. For everyone on the
                 platform, use{' '}
                 <button
                   type="button"
@@ -96,7 +96,7 @@ export function LabRoster() {
             <div className="bs-cards">
               {members.length === 0 ? (
                 <div className="bs-empty">
-                  No one is on your lab roster yet. Accept applicants from your position pipelines — they will show up
+                  No one is on your lab roster yet. Accept applicants from your position pipelines; they will show up
                   here automatically.
                 </div>
               ) : (
@@ -138,7 +138,7 @@ export function LabRoster() {
                                   <span className="bs-card-gpa-val">{Number(s.gpa).toFixed(2)}</span>
                                 </>
                               ) : (
-                                <span className="bs-card-gpa-empty">—</span>
+                                <span className="bs-card-gpa-empty">N/A</span>
                               )}
                             </div>
                           </div>

--- a/client/src/pages/pi/PIDashboard.tsx
+++ b/client/src/pages/pi/PIDashboard.tsx
@@ -33,9 +33,9 @@ const statusStyles: Record<
 };
 
 function daysUntil(dateStr: string | null): string {
-  if (!dateStr) return '—';
+  if (!dateStr) return 'N/A';
   const d = new Date(dateStr);
-  if (Number.isNaN(d.getTime())) return '—';
+  if (Number.isNaN(d.getTime())) return 'N/A';
   const now = new Date();
   const end = new Date(d.getFullYear(), d.getMonth(), d.getDate());
   const start = new Date(now.getFullYear(), now.getMonth(), now.getDate());
@@ -191,7 +191,7 @@ export function PIDashboard() {
                 <div className="pi-dash-stat-label">Acceptance Rate</div>
                 <div className="pi-dash-stat-row">
                   <div className="pi-dash-stat-value">
-                    {acceptanceRate != null ? `${acceptanceRate}%` : '—'}
+                    {acceptanceRate != null ? `${acceptanceRate}%` : 'N/A'}
                   </div>
                 </div>
                 <div className="pi-dash-stat-sub">
@@ -203,7 +203,7 @@ export function PIDashboard() {
               <div className="pi-dash-stat">
                 <div className="pi-dash-stat-label">Avg. Time to Fill</div>
                 <div className="pi-dash-stat-row">
-                  <div className="pi-dash-stat-value">—</div>
+                  <div className="pi-dash-stat-value">N/A</div>
                 </div>
                 <div className="pi-dash-stat-sub">From post to accept</div>
               </div>
@@ -307,7 +307,7 @@ export function PIDashboard() {
                     const st = statusStyles[a.status] || statusStyles.pending;
                     const name = [a.firstName, a.lastName].filter(Boolean).join(' ') || 'Student';
                     const gpaStr = a.gpa != null ? `${Number(a.gpa).toFixed(1)} GPA` : '';
-                    const majorStr = a.major || '—';
+                    const majorStr = a.major || 'N/A';
                     return (
                       <Link key={a.id} to={`/pi/students/${a.studentId}`} className="pi-dash-app-row">
                         <div className="pi-dash-app-avatar">{initials(a.firstName, a.lastName)}</div>

--- a/client/src/pages/pi/PositionApplications.tsx
+++ b/client/src/pages/pi/PositionApplications.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import { Navbar } from '../../components/Navbar';
 import { Modal } from '../../components/Modal';
 import { api } from '../../lib/api';
-import type { AcademicLevel } from '../../types';
+import type { AcademicLevel, Position } from '../../types';
 import './position-applications.css';
 
 interface AppWithStudent {
@@ -21,6 +21,7 @@ interface AppWithStudent {
   bio?: string;
   resumeUrl?: string;
   yearLevel?: string;
+  questionAnswers?: Record<string, string | number>;
 }
 
 function initials(first?: string, last?: string): string {
@@ -75,14 +76,14 @@ function pillLabel(status: string): string {
 export function PositionApplications() {
   const { id } = useParams<{ id: string }>();
   const [applications, setApplications] = useState<AppWithStudent[]>([]);
-  const [positionTitle, setPositionTitle] = useState('');
+  const [position, setPosition] = useState<Position | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedApp, setSelectedApp] = useState<AppWithStudent | null>(null);
   const [updating, setUpdating] = useState(false);
 
   useEffect(() => {
     if (!id) return;
-    api.positions.getById(id).then((p) => setPositionTitle(p.title));
+    api.positions.getById(id).then(setPosition).catch(() => setPosition(null));
     api.applications
       .byPosition(id)
       .then(setApplications)
@@ -122,7 +123,7 @@ export function PositionApplications() {
             <Link to="/pi/dashboard" className="pa-back">
               ← Back to dashboard
             </Link>
-            <h1 className="pa-title">{positionTitle || 'Position'}</h1>
+            <h1 className="pa-title">{position?.title || 'Position'}</h1>
             <p className="pa-subtitle">
               {applications.length} applicant{applications.length !== 1 ? 's' : ''}
             </p>
@@ -231,6 +232,32 @@ export function PositionApplications() {
                 <p className="mt-1 whitespace-pre-wrap text-slate-300">{selectedApp.coverLetter}</p>
               </div>
             )}
+            {selectedApp.questionAnswers &&
+              Object.keys(selectedApp.questionAnswers).length > 0 &&
+              (position?.applicationQuestions?.length ? (
+                <div>
+                  <strong className="text-slate-100">Application questions:</strong>
+                  <ul className="mt-2 space-y-2 list-none pl-0">
+                    {position.applicationQuestions.map((q) => {
+                      const v = selectedApp.questionAnswers?.[q.id];
+                      if (v === undefined || v === null) return null;
+                      return (
+                        <li key={q.id}>
+                          <span className="text-slate-200 font-medium">{q.label}: </span>
+                          <span className="text-slate-300 whitespace-pre-wrap">{String(v)}</span>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ) : (
+                <div>
+                  <strong className="text-slate-100">Extra answers:</strong>
+                  <pre className="mt-1 text-slate-300 text-xs whitespace-pre-wrap">
+                    {JSON.stringify(selectedApp.questionAnswers, null, 2)}
+                  </pre>
+                </div>
+              ))}
             <Link
               to={`/pi/students/${selectedApp.studentId}`}
               className="inline-block mt-2 text-blue-400 hover:underline"

--- a/client/src/pages/pi/PositionEdit.tsx
+++ b/client/src/pages/pi/PositionEdit.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { Navbar } from '../../components/Navbar';
+import { ApplicationQuestionsEditor } from '../../components/ApplicationQuestionsEditor';
 import { api } from '../../lib/api';
 import type { Position } from '../../types';
+import type { ApplicationQuestion } from '../../types/applicationQuestions';
 
 export function PositionEdit() {
   const { id } = useParams<{ id: string }>();
@@ -12,6 +14,7 @@ export function PositionEdit() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [confirmClose, setConfirmClose] = useState(false);
+  const [applicationQuestions, setApplicationQuestions] = useState<ApplicationQuestion[]>([]);
   const [form, setForm] = useState({
     title: '',
     description: '',
@@ -28,6 +31,9 @@ export function PositionEdit() {
       .getById(id)
       .then((p) => {
         setPosition(p);
+        setApplicationQuestions(
+          Array.isArray(p.applicationQuestions) ? (p.applicationQuestions as ApplicationQuestion[]) : []
+        );
         setForm({
           title: p.title,
           description: p.description || '',
@@ -59,6 +65,7 @@ export function PositionEdit() {
         isOpen: form.isOpen,
         isFunded: form.isFunded,
         deadline: form.deadline || undefined,
+        applicationQuestions: applicationQuestions.filter((q) => q.label.trim()),
       });
       navigate('/pi/dashboard');
     } catch (err: unknown) {
@@ -190,6 +197,7 @@ export function PositionEdit() {
               Funded position
             </label>
           </div>
+          <ApplicationQuestionsEditor value={applicationQuestions} onChange={setApplicationQuestions} />
           <div className="flex gap-3">
             <button
               type="submit"

--- a/client/src/pages/pi/PositionNew.tsx
+++ b/client/src/pages/pi/PositionNew.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { Navbar } from '../../components/Navbar';
+import { ApplicationQuestionsEditor } from '../../components/ApplicationQuestionsEditor';
 import { api } from '../../lib/api';
+import type { ApplicationQuestion } from '../../types/applicationQuestions';
 
 export function PositionNew() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [applicationQuestions, setApplicationQuestions] = useState<ApplicationQuestion[]>([]);
   const [form, setForm] = useState({
     title: '',
     description: '',
@@ -35,6 +38,7 @@ export function PositionNew() {
         minGpa: form.minGpa ? parseFloat(form.minGpa) : undefined,
         isFunded: form.isFunded,
         deadline: form.deadline || undefined,
+        applicationQuestions: applicationQuestions.filter((q) => q.label.trim()),
       });
       navigate(`/pi/positions/${position.id}/edit`);
     } catch (err: unknown) {
@@ -120,6 +124,7 @@ export function PositionNew() {
               Funded position
             </label>
           </div>
+          <ApplicationQuestionsEditor value={applicationQuestions} onChange={setApplicationQuestions} />
           <button
             type="submit"
             disabled={loading}

--- a/client/src/pages/pi/StudentDetail.tsx
+++ b/client/src/pages/pi/StudentDetail.tsx
@@ -27,7 +27,7 @@ function formatYearLabel(yl: string | null | undefined): string {
 }
 
 function displayValue(v: string | number | null | undefined): string {
-  if (v === null || v === undefined || v === '') return '—';
+  if (v === null || v === undefined || v === '') return 'N/A';
   return String(v);
 }
 
@@ -87,10 +87,10 @@ export function StudentDetail() {
   const email = student.email ?? '';
   const yearVal = formatYearLabel(student.yearLevel as AcademicLevel | null | undefined);
   const gradVal =
-    student.graduationYear != null ? String(student.graduationYear) : '—';
+    student.graduationYear != null ? String(student.graduationYear) : 'N/A';
   const majorVal = displayValue(student.major);
-  const gpaVal = student.gpa != null ? Number(student.gpa).toFixed(1) : '—';
-  const yearDisplay = yearVal || '—';
+  const gpaVal = student.gpa != null ? Number(student.gpa).toFixed(1) : 'N/A';
+  const yearDisplay = yearVal || 'N/A';
 
   return (
     <div className="min-h-screen">

--- a/client/src/pages/pi/StudentList.tsx
+++ b/client/src/pages/pi/StudentList.tsx
@@ -33,7 +33,7 @@ function formatYearLabel(yl: AcademicLevel | null | undefined): string {
   return map[yl] || yl;
 }
 
-/** Name + email only — nothing meaningful in profile fields */
+/** Name + email only; nothing meaningful in profile fields */
 function isProfileIncomplete(s: StudentProfile): boolean {
   const has =
     Boolean(s.major?.trim()) ||
@@ -159,7 +159,7 @@ export function StudentList() {
             <header className="bs-header">
               <h1 className="bs-title">Students</h1>
               <p className="bs-subtitle">
-                {allStudents.length} with a profile on ResearchHub — browse, open a profile, and reach out (e.g. email)
+                {allStudents.length} with a profile on ResearchHub: browse, open a profile, and reach out (e.g. email)
                 to recruit. Your active hires are listed under Lab → Roster.
               </p>
             </header>
@@ -289,7 +289,7 @@ export function StudentList() {
                               <span className="bs-card-gpa-val">{Number(s.gpa).toFixed(2)}</span>
                             </>
                           ) : (
-                            <span className="bs-card-gpa-empty">—</span>
+                            <span className="bs-card-gpa-empty">N/A</span>
                           )}
                         </div>
                       </div>

--- a/client/src/pages/student/PositionDetail.tsx
+++ b/client/src/pages/student/PositionDetail.tsx
@@ -3,7 +3,8 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { FlaskConical } from 'lucide-react';
 import { Navbar } from '../../components/Navbar';
 import { api, ApiError } from '../../lib/api';
-import type { Position } from '../../types';
+import type { Application, Position, QuestionAnswersMap } from '../../types';
+import type { ApplicationQuestion } from '../../types/applicationQuestions';
 import './position-detail.css';
 
 function formatDeadlineLong(iso: string | null): string {
@@ -26,31 +27,105 @@ function deadlineCountdown(iso: string | null): { kind: 'ok' | 'closed' | 'none'
   return { kind: 'ok', daysText: `(${diffDays} days left)` };
 }
 
+function buildAnswersPayload(
+  questions: ApplicationQuestion[],
+  raw: Record<string, string>
+): QuestionAnswersMap {
+  const out: QuestionAnswersMap = {};
+  for (const q of questions) {
+    const v = raw[q.id];
+    if (v === undefined || String(v).trim() === '') continue;
+    if (q.type === 'number') {
+      const n = Number(String(v).trim());
+      if (!Number.isNaN(n)) out[q.id] = n;
+    } else {
+      out[q.id] = String(v).trim();
+    }
+  }
+  return out;
+}
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'pending':
+      return 'pd-status pd-status-pending';
+    case 'reviewing':
+      return 'pd-status pd-status-reviewing';
+    case 'accepted':
+      return 'pd-status pd-status-accepted';
+    case 'rejected':
+      return 'pd-status pd-status-rejected';
+    case 'withdrawn':
+      return 'pd-status pd-status-withdrawn';
+    default:
+      return 'pd-status pd-status-pending';
+  }
+}
+
+function statusLabel(status: string): string {
+  const labels: Record<string, string> = {
+    pending: 'Pending',
+    reviewing: 'Reviewing',
+    accepted: 'Accepted',
+    rejected: 'Rejected',
+    withdrawn: 'Withdrawn',
+  };
+  return labels[status] ?? status;
+}
+
 export function PositionDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [position, setPosition] = useState<Position | null>(null);
+  const [existingApp, setExistingApp] = useState<Application | null>(null);
+  const [appsLoading, setAppsLoading] = useState(true);
   const [loading, setLoading] = useState(true);
   const [applying, setApplying] = useState(false);
   const [coverLetter, setCoverLetter] = useState('');
+  const [answerDraft, setAnswerDraft] = useState<Record<string, string>>({});
   const [error, setError] = useState('');
 
   useEffect(() => {
     if (!id) return;
-    api.positions
-      .getById(id)
-      .then(setPosition)
-      .catch(() => setPosition(null))
-      .finally(() => setLoading(false));
+    setExistingApp(null);
+    setAppsLoading(true);
+    setLoading(true);
+    Promise.all([
+      api.positions.getById(id).catch(() => null),
+      api.applications.mine().catch(() => [] as Application[]),
+    ])
+      .then(([pos, apps]) => {
+        setPosition(pos);
+        const found = apps.find((a) => a.positionId === id) ?? null;
+        setExistingApp(found);
+      })
+      .finally(() => {
+        setLoading(false);
+        setAppsLoading(false);
+      });
   }, [id]);
 
   const handleApply = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!id) return;
+    if (!id || !position) return;
+    const questions = (position.applicationQuestions || []).filter((q) => q.label?.trim());
     setError('');
+    for (const q of questions) {
+      if (!q.required) continue;
+      const v = answerDraft[q.id];
+      if (v === undefined || String(v).trim() === '') {
+        setError(`Please answer: ${q.label}`);
+        return;
+      }
+    }
     setApplying(true);
     try {
-      await api.applications.create({ positionId: id, coverLetter: coverLetter || undefined });
+      const questionAnswers = buildAnswersPayload(questions, answerDraft);
+      await api.applications.create({
+        positionId: id,
+        coverLetter: coverLetter || undefined,
+        questionAnswers: Object.keys(questionAnswers).length ? questionAnswers : undefined,
+      });
       navigate('/student/applications');
     } catch (err) {
       if (err instanceof ApiError) {
@@ -98,6 +173,8 @@ export function PositionDetail() {
 
   const deadlineLong = formatDeadlineLong(position.deadline);
   const countdown = deadlineCountdown(position.deadline);
+  const customQuestions = (position.applicationQuestions || []).filter((q) => q.label?.trim());
+  const submitted = !!existingApp;
 
   return (
     <div className="pd-page">
@@ -131,7 +208,7 @@ export function PositionDetail() {
 
           <div>
             <h2 className="pd-section-label">About This Position</h2>
-            <p className="pd-desc-body">{position.description || '—'}</p>
+            <p className="pd-desc-body">{position.description || 'No description provided.'}</p>
           </div>
 
           <hr className="pd-divider" />
@@ -182,8 +259,52 @@ export function PositionDetail() {
         </div>
 
         <div className="pd-card">
-          <h2 className="pd-apply-title">Apply for This Position</h2>
-          {!position.isOpen ? (
+          <h2 className="pd-apply-title">
+            {submitted ? 'Your application' : 'Apply for This Position'}
+          </h2>
+          {appsLoading ? (
+            <p className="text-sm text-[#8b90ad]">Loading application status…</p>
+          ) : submitted && existingApp ? (
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-medium text-[#3d4260]">Status:</span>
+                <span className={statusBadgeClass(existingApp.status)}>{statusLabel(existingApp.status)}</span>
+                <span className="text-sm text-[#8b90ad]">
+                  Submitted{' '}
+                  {new Date(existingApp.appliedAt).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </span>
+              </div>
+              <p className="text-sm text-[#5c617a]">
+                You cannot edit a submitted application. This page is for your records only.
+              </p>
+              {existingApp.coverLetter?.trim() ? (
+                <div>
+                  <h3 className="pd-label">Cover letter</h3>
+                  <p className="pd-desc-body whitespace-pre-wrap">{existingApp.coverLetter}</p>
+                </div>
+              ) : null}
+              {customQuestions.length > 0 ? (
+                <div className="space-y-3">
+                  <h3 className="pd-label">Your answers</h3>
+                  {customQuestions.map((q) => {
+                    const ans = existingApp.questionAnswers?.[q.id];
+                    const display =
+                      ans === undefined || ans === null ? 'No answer' : String(ans);
+                    return (
+                      <div key={q.id}>
+                        <p className="text-sm font-medium text-[#3d4260]">{q.label}</p>
+                        <p className="pd-desc-body whitespace-pre-wrap">{display}</p>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </div>
+          ) : !position.isOpen ? (
             <p className="pd-closed-msg">This position is no longer accepting applications.</p>
           ) : (
             <form onSubmit={handleApply}>
@@ -198,6 +319,71 @@ export function PositionDetail() {
                 placeholder="Why are you interested in this position? Mention relevant coursework or experience..."
                 className="pd-textarea"
               />
+              {customQuestions.map((q) => (
+                <div key={q.id} className="mt-4">
+                  <label className="pd-label" htmlFor={`pd-q-${q.id}`}>
+                    {q.label}
+                    {q.required ? ' *' : ''}
+                  </label>
+                  {q.type === 'text' && (
+                    <textarea
+                      id={`pd-q-${q.id}`}
+                      value={answerDraft[q.id] ?? ''}
+                      onChange={(e) =>
+                        setAnswerDraft((d) => ({ ...d, [q.id]: e.target.value }))
+                      }
+                      className="pd-textarea"
+                      rows={3}
+                    />
+                  )}
+                  {q.type === 'number' && (
+                    <input
+                      id={`pd-q-${q.id}`}
+                      type="number"
+                      step="any"
+                      value={answerDraft[q.id] ?? ''}
+                      onChange={(e) =>
+                        setAnswerDraft((d) => ({ ...d, [q.id]: e.target.value }))
+                      }
+                      className="pd-textarea py-2"
+                    />
+                  )}
+                  {q.type === 'dropdown' && (
+                    <select
+                      id={`pd-q-${q.id}`}
+                      value={answerDraft[q.id] ?? ''}
+                      onChange={(e) =>
+                        setAnswerDraft((d) => ({ ...d, [q.id]: e.target.value }))
+                      }
+                      className="pd-textarea py-2"
+                    >
+                      <option value="">Select…</option>
+                      {(q.options || []).map((opt) => (
+                        <option key={opt} value={opt}>
+                          {opt}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                  {q.type === 'choice' && (
+                    <fieldset id={`pd-q-${q.id}`} className="pd-choice-group">
+                      <legend className="sr-only">{q.label}</legend>
+                      {(q.options || []).map((opt) => (
+                        <label key={opt} className="pd-choice-row">
+                          <input
+                            type="radio"
+                            name={`pd-q-${q.id}`}
+                            value={opt}
+                            checked={(answerDraft[q.id] ?? '') === opt}
+                            onChange={() => setAnswerDraft((d) => ({ ...d, [q.id]: opt }))}
+                          />
+                          <span>{opt}</span>
+                        </label>
+                      ))}
+                    </fieldset>
+                  )}
+                </div>
+              ))}
               <button type="submit" className="pd-submit" disabled={applying}>
                 {applying ? 'Submitting…' : 'Submit Application'}
               </button>

--- a/client/src/pages/student/PositionList.tsx
+++ b/client/src/pages/student/PositionList.tsx
@@ -292,7 +292,7 @@ export function PositionList() {
                       </div>
                       {p.department ? <div className="bp-card-dept">{p.department}</div> : null}
 
-                      <div className="bp-card-desc">{p.description || '—'}</div>
+                      <div className="bp-card-desc">{p.description || 'No description.'}</div>
 
                       <div className="bp-card-footer">
                         <div className="bp-card-skills">

--- a/client/src/pages/student/StudentApplications.tsx
+++ b/client/src/pages/student/StudentApplications.tsx
@@ -30,7 +30,7 @@ function relativeAppliedLabel(iso: string): string {
   const diffDays = Math.round(
     (startToday.getTime() - startD.getTime()) / (24 * 60 * 60 * 1000)
   );
-  if (diffDays < 0) return '—';
+  if (diffDays < 0) return '';
   if (diffDays === 0) return 'Today';
   if (diffDays === 1) return '1d ago';
   if (diffDays < 7) return `${diffDays}d ago`;

--- a/client/src/pages/student/StudentSettings.tsx
+++ b/client/src/pages/student/StudentSettings.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Navbar } from '../../components/Navbar';
+
+const STORAGE_PREFIX = 'rh-student-settings-';
+
+type SettingsState = {
+  emailStatusUpdates: boolean;
+  emailDigest: boolean;
+  browserNotifications: boolean;
+};
+
+const DEFAULTS: SettingsState = {
+  emailStatusUpdates: true,
+  emailDigest: false,
+  browserNotifications: false,
+};
+
+function loadSettings(): SettingsState {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}v1`);
+    if (!raw) return { ...DEFAULTS };
+    const p = JSON.parse(raw) as Partial<SettingsState>;
+    return {
+      emailStatusUpdates: typeof p.emailStatusUpdates === 'boolean' ? p.emailStatusUpdates : DEFAULTS.emailStatusUpdates,
+      emailDigest: typeof p.emailDigest === 'boolean' ? p.emailDigest : DEFAULTS.emailDigest,
+      browserNotifications: typeof p.browserNotifications === 'boolean' ? p.browserNotifications : DEFAULTS.browserNotifications,
+    };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+export function StudentSettings() {
+  const [settings, setSettings] = useState<SettingsState>(DEFAULTS);
+  const [savedFlash, setSavedFlash] = useState(false);
+
+  useEffect(() => {
+    setSettings(loadSettings());
+  }, []);
+
+  const persist = (next: SettingsState) => {
+    setSettings(next);
+    localStorage.setItem(`${STORAGE_PREFIX}v1`, JSON.stringify(next));
+    setSavedFlash(true);
+    window.setTimeout(() => setSavedFlash(false), 2000);
+  };
+
+  const toggle = (key: keyof SettingsState) => {
+    persist({ ...settings, [key]: !settings[key] });
+  };
+
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <div className="max-w-2xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-inherit mb-2">Settings</h1>
+        <p className="text-slate-600 text-sm mb-8">
+          Notifications and preferences. Profile details (major, resume, bio) are under{' '}
+          <Link to="/student/profile" className="text-teal-600 hover:underline">
+            Profile
+          </Link>
+          .
+        </p>
+
+        {savedFlash ? (
+          <div className="mb-4 p-3 bg-teal-50 text-teal-800 rounded-lg text-sm">Preferences saved on this device.</div>
+        ) : null}
+
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">Notifications</h2>
+            <div className="space-y-4 border border-slate-200 rounded-lg p-4 bg-white">
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="mt-1 rounded border-slate-300"
+                  checked={settings.emailStatusUpdates}
+                  onChange={() => toggle('emailStatusUpdates')}
+                />
+                <span>
+                  <span className="font-medium text-inherit block">Application status emails</span>
+                  <span className="text-sm text-slate-600">
+                    When a lab updates your application (e.g. reviewing, accepted). Email delivery depends on server
+                    configuration.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="mt-1 rounded border-slate-300"
+                  checked={settings.emailDigest}
+                  onChange={() => toggle('emailDigest')}
+                />
+                <span>
+                  <span className="font-medium text-inherit block">Weekly digest</span>
+                  <span className="text-sm text-slate-600">Summary of new positions that match your skills (when available).</span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="mt-1 rounded border-slate-300"
+                  checked={settings.browserNotifications}
+                  onChange={() => toggle('browserNotifications')}
+                />
+                <span>
+                  <span className="font-medium text-inherit block">Browser reminders</span>
+                  <span className="text-sm text-slate-600">Optional on-device reminders for deadlines you save later.</span>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">Miscellaneous</h2>
+            <div className="border border-slate-200 rounded-lg p-4 bg-white text-sm text-slate-600">
+              More preferences (language, accessibility) can be added here as the product grows.
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/student/position-detail.css
+++ b/client/src/pages/student/position-detail.css
@@ -1,4 +1,4 @@
-/* Student position detail — IBM Plex Sans from global */
+/* Student position detail: IBM Plex Sans from global */
 .pd-page {
   min-height: 100vh;
   background: #f6f7fb;
@@ -262,4 +262,65 @@
   font-size: 14px;
   color: #6b7194;
   margin: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pd-choice-group {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pd-choice-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 14px;
+  color: #3d4260;
+  cursor: pointer;
+}
+
+.pd-choice-row input {
+  accent-color: #3b5bdb;
+}
+
+.pd-status {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.pd-status-pending {
+  background: #fff3bf;
+  color: #946c00;
+}
+.pd-status-reviewing {
+  background: #d0ebff;
+  color: #1864ab;
+}
+.pd-status-accepted {
+  background: #d3f9d8;
+  color: #2b8a3e;
+}
+.pd-status-rejected {
+  background: #ffe3e3;
+  color: #c92a2a;
+}
+.pd-status-withdrawn {
+  background: #e9ecef;
+  color: #495057;
 }

--- a/client/src/types/applicationQuestions.ts
+++ b/client/src/types/applicationQuestions.ts
@@ -1,0 +1,12 @@
+export type ApplicationQuestionType = 'text' | 'number' | 'dropdown' | 'choice';
+
+export interface ApplicationQuestion {
+  id: string;
+  type: ApplicationQuestionType;
+  label: string;
+  required?: boolean;
+  /** Required when type is dropdown or choice */
+  options?: string[];
+}
+
+export type QuestionAnswersMap = Record<string, string | number>;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,3 +1,7 @@
+import type { ApplicationQuestion, QuestionAnswersMap } from './applicationQuestions';
+
+export type { ApplicationQuestion, QuestionAnswersMap } from './applicationQuestions';
+
 export type UserRole = 'student' | 'pi';
 export type AcademicLevel = 'freshman' | 'sophomore' | 'junior' | 'senior' | 'grad' | 'masters' | 'phd' | 'postdoc';
 /** @deprecated Use AcademicLevel */
@@ -34,7 +38,7 @@ export interface StudentProfile {
 /** PI lab roster: students with an accepted application to one of this PI's positions */
 export interface LabRosterMember extends StudentProfile {
   acceptedPositionTitles: string[];
-  /** ISO timestamp — earliest acceptance update for this PI's positions */
+  /** ISO timestamp: earliest acceptance update for this PI's positions */
   inLabSince: string;
 }
 
@@ -78,6 +82,8 @@ export interface Position {
   /** Present on position detail (from PI user record) */
   piFirstName?: string;
   piLastName?: string;
+  /** Custom questions applicants answer (set by PI) */
+  applicationQuestions?: ApplicationQuestion[];
 }
 
 export interface Application {
@@ -91,4 +97,6 @@ export interface Application {
   appliedAt: string;
   positionTitle?: string;
   labName?: string;
+  department?: string | null;
+  questionAnswers?: QuestionAnswersMap;
 }

--- a/server/src/db/migrate.ts
+++ b/server/src/db/migrate.ts
@@ -6,18 +6,64 @@ import pool from './pool.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+function parseArg(name: string): string | undefined {
+  const prefix = `${name}=`;
+  const raw = process.argv.find((a) => a.startsWith(prefix));
+  return raw ? raw.slice(prefix.length) : undefined;
+}
+
 async function migrate() {
+  const skipUntil = parseArg('--skip-until');
   const client = await pool.connect();
   try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        name VARCHAR(255) PRIMARY KEY,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+
     const migrationsDir = join(__dirname, 'migrations');
     const files = readdirSync(migrationsDir)
       .filter((f) => f.endsWith('.sql'))
       .sort();
 
+    if (skipUntil) {
+      if (!files.includes(skipUntil)) {
+        throw new Error(
+          `--skip-until: no migration file "${skipUntil}". Files: ${files.join(', ')}`
+        );
+      }
+      for (const file of files) {
+        if (file < skipUntil) {
+          await client.query(
+            `INSERT INTO schema_migrations (name) VALUES ($1) ON CONFLICT (name) DO NOTHING`,
+            [file]
+          );
+        }
+      }
+      console.log(
+        `Recorded migrations lexicographically before "${skipUntil}" as already applied (no SQL run for those).`
+      );
+    }
+
     for (const file of files) {
+      const done = await client.query('SELECT 1 FROM schema_migrations WHERE name = $1', [file]);
+      if (done.rowCount) {
+        console.log(`Skipping already applied: ${file}`);
+        continue;
+      }
       const sql = readFileSync(join(migrationsDir, file), 'utf-8');
       console.log(`Running migration: ${file}`);
-      await client.query(sql);
+      await client.query('BEGIN');
+      try {
+        await client.query(sql);
+        await client.query('INSERT INTO schema_migrations (name) VALUES ($1)', [file]);
+        await client.query('COMMIT');
+      } catch (e) {
+        await client.query('ROLLBACK');
+        throw e;
+      }
     }
     console.log('Migrations complete.');
   } finally {
@@ -26,7 +72,15 @@ async function migrate() {
   }
 }
 
-migrate().catch((err) => {
+migrate().catch((err: unknown) => {
   console.error('Migration failed:', err);
+  const e = err as { code?: string };
+  if (e.code === '42710' || e.code === '42P07') {
+    console.error(
+      '\nIf this database was created outside this migrate script, mark older migrations as applied, then rerun:\n' +
+        '  npm run migrate -- --skip-until=006_application_questions.sql\n' +
+        '(Use the first migration file you have not yet applied; filenames are compared in sort order.)\n'
+    );
+  }
   process.exit(1);
 });

--- a/server/src/db/migrations/006_application_questions.sql
+++ b/server/src/db/migrations/006_application_questions.sql
@@ -1,0 +1,6 @@
+-- Custom application questions on positions and answers on applications
+ALTER TABLE research_positions
+  ADD COLUMN IF NOT EXISTS application_questions jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS question_answers jsonb NOT NULL DEFAULT '{}'::jsonb;

--- a/server/src/db/schema.sql
+++ b/server/src/db/schema.sql
@@ -92,6 +92,7 @@ create table if not exists research_positions (
   time_commitment   text,
   deadline          timestamptz,
   status            position_status  not null default 'open',
+  application_questions jsonb        not null default '[]'::jsonb,
   created_at        timestamptz      not null default now(),
   updated_at        timestamptz      not null default now()
 );
@@ -127,6 +128,7 @@ create table if not exists applications (
   student_id         uuid not null references student_profiles (id) on delete cascade,
   position_id        uuid not null references research_positions (id) on delete cascade,
   personal_statement text,
+  question_answers   jsonb                not null default '{}'::jsonb,
   status             application_status not null default 'pending',
   created_at         timestamptz not null default now(),
   updated_at         timestamptz not null default now(),

--- a/server/src/lib/applicationQuestions.ts
+++ b/server/src/lib/applicationQuestions.ts
@@ -1,0 +1,93 @@
+export type ApplicationQuestionType = 'text' | 'number' | 'dropdown' | 'choice';
+
+export interface ApplicationQuestion {
+  id: string;
+  type: ApplicationQuestionType;
+  label: string;
+  required?: boolean;
+  options?: string[];
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+export function parseApplicationQuestions(raw: unknown): ApplicationQuestion[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ApplicationQuestion[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    const id = typeof o.id === 'string' && o.id.trim() ? o.id.trim() : null;
+    const type = o.type;
+    const label = typeof o.label === 'string' ? o.label.trim() : '';
+    if (!id || !label) continue;
+    if (type !== 'text' && type !== 'number' && type !== 'dropdown' && type !== 'choice') continue;
+    const required = Boolean(o.required);
+    let options: string[] | undefined;
+    if (type === 'dropdown' || type === 'choice') {
+      if (!Array.isArray(o.options)) continue;
+      options = o.options
+        .filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
+        .map((x) => x.trim());
+      if (options.length === 0) continue;
+    }
+    out.push({ id, type, label, required, options });
+  }
+  return out;
+}
+
+/** Returns error message or null if valid */
+export function validateQuestionAnswers(
+  questions: ApplicationQuestion[],
+  answers: Record<string, unknown>
+): string | null {
+  for (const q of questions) {
+    const raw = answers[q.id];
+    const missing =
+      raw === undefined ||
+      raw === null ||
+      (typeof raw === 'string' && !raw.trim()) ||
+      (typeof raw === 'number' && Number.isNaN(raw));
+
+    if (q.required && missing) {
+      return `Answer required: ${q.label}`;
+    }
+    if (missing) continue;
+
+    if (q.type === 'number') {
+      const n = typeof raw === 'number' ? raw : Number(String(raw).trim());
+      if (Number.isNaN(n)) {
+        return `Invalid number for: ${q.label}`;
+      }
+    }
+    if (q.type === 'dropdown' || q.type === 'choice') {
+      const s = String(raw).trim();
+      const opts = q.options || [];
+      if (!opts.includes(s)) {
+        return `Invalid choice for: ${q.label}`;
+      }
+    }
+  }
+  return null;
+}
+
+export function normalizeAnswersForStore(
+  questions: ApplicationQuestion[],
+  answers: Record<string, unknown>
+): Record<string, string | number> {
+  const out: Record<string, string | number> = {};
+  for (const q of questions) {
+    const raw = answers[q.id];
+    if (raw === undefined || raw === null) continue;
+    if (q.type === 'number') {
+      const n = typeof raw === 'number' ? raw : Number(String(raw).trim());
+      if (!Number.isNaN(n)) out[q.id] = n;
+      continue;
+    }
+    if (isNonEmptyString(raw)) {
+      out[q.id] = raw.trim();
+    }
+  }
+  return out;
+}

--- a/server/src/routes/applications.ts
+++ b/server/src/routes/applications.ts
@@ -2,12 +2,17 @@ import { Router, Request, Response } from 'express';
 import pool from '../db/pool.js';
 import { authMiddleware, requireRole } from '../middleware/auth.js';
 import { asyncHandler } from '../lib/asyncHandler.js';
+import {
+  normalizeAnswersForStore,
+  parseApplicationQuestions,
+  validateQuestionAnswers,
+} from '../lib/applicationQuestions.js';
 
 const router = Router();
 
 // POST /api/applications - apply (student only)
 router.post('/', authMiddleware, requireRole('student'), asyncHandler(async (req: Request, res: Response) => {
-  const { positionId, coverLetter, personalStatement } = req.body;
+  const { positionId, coverLetter, personalStatement, questionAnswers } = req.body;
   if (!positionId) {
     return res.status(400).json({ error: 'positionId is required' });
   }
@@ -16,13 +21,37 @@ router.post('/', authMiddleware, requireRole('student'), asyncHandler(async (req
   if (!student) {
     return res.status(404).json({ error: 'Student profile not found' });
   }
+
+  const posResult = await pool.query(
+    `SELECT id, status, application_questions FROM research_positions WHERE id = $1`,
+    [positionId]
+  );
+  const posRow = posResult.rows[0];
+  if (!posRow) {
+    return res.status(404).json({ error: 'Position not found' });
+  }
+  if (posRow.status !== 'open') {
+    return res.status(400).json({ error: 'This position is not accepting applications' });
+  }
+
+  const questions = parseApplicationQuestions(posRow.application_questions);
+  const answersIn =
+    questionAnswers && typeof questionAnswers === 'object' && !Array.isArray(questionAnswers)
+      ? (questionAnswers as Record<string, unknown>)
+      : {};
+  const errMsg = validateQuestionAnswers(questions, answersIn);
+  if (errMsg) {
+    return res.status(400).json({ error: errMsg });
+  }
+  const answersJson = JSON.stringify(normalizeAnswersForStore(questions, answersIn));
+
   const statement = personalStatement ?? coverLetter ?? null;
   try {
     const result = await pool.query(
-      `INSERT INTO applications (position_id, student_id, personal_statement)
-       VALUES ($1, $2, $3)
+      `INSERT INTO applications (position_id, student_id, personal_statement, question_answers)
+       VALUES ($1, $2, $3, $4::jsonb)
        RETURNING *`,
-      [positionId, student.id, statement]
+      [positionId, student.id, statement, answersJson]
     );
     const row = result.rows[0];
     return res.status(201).json({
@@ -33,6 +62,7 @@ router.post('/', authMiddleware, requireRole('student'), asyncHandler(async (req
       coverLetter: row.personal_statement,
       personalStatement: row.personal_statement,
       appliedAt: row.created_at,
+      questionAnswers: row.question_answers || {},
     });
   } catch (err: unknown) {
     const e = err as { code?: string };
@@ -51,7 +81,7 @@ router.get('/mine', authMiddleware, requireRole('student'), asyncHandler(async (
     return res.json([]);
   }
   const result = await pool.query(
-    `SELECT a.*, rp.title as position_title, pp.lab_name
+    `SELECT a.*, rp.title as position_title, pp.lab_name, pp.department
      FROM applications a
      JOIN research_positions rp ON rp.id = a.position_id
      JOIN pi_profiles pp ON pp.id = rp.pi_id
@@ -70,6 +100,8 @@ router.get('/mine', authMiddleware, requireRole('student'), asyncHandler(async (
       appliedAt: row.created_at,
       positionTitle: row.position_title,
       labName: row.lab_name,
+      department: row.department,
+      questionAnswers: row.question_answers || {},
     }))
   );
 }));
@@ -111,6 +143,7 @@ router.get('/position/:id', authMiddleware, requireRole('pi'), asyncHandler(asyn
       firstName: row.first_name,
       lastName: row.last_name,
       email: row.email,
+      questionAnswers: row.question_answers || {},
     }))
   );
 }));
@@ -148,6 +181,7 @@ router.patch('/:id/status', authMiddleware, requireRole('pi'), asyncHandler(asyn
     coverLetter: row.personal_statement,
     personalStatement: row.personal_statement,
     appliedAt: row.created_at,
+    questionAnswers: row.question_answers || {},
   });
 }));
 

--- a/server/src/routes/positions.ts
+++ b/server/src/routes/positions.ts
@@ -6,6 +6,7 @@ import { asyncHandler } from '../lib/asyncHandler.js';
 const router = Router();
 
 function rowToPosition(row: Record<string, unknown>) {
+  const aq = row.application_questions;
   return {
     id: row.id,
     piId: row.pi_id,
@@ -25,12 +26,13 @@ function rowToPosition(row: Record<string, unknown>) {
     labName: row.lab_name,
     researchArea: (row.research_areas as string[] | undefined)?.join(', ') || null,
     labWebsite: row.lab_website,
+    applicationQuestions: Array.isArray(aq) ? aq : [],
   };
 }
 
 // POST /api/positions - create (PI only)
 router.post('/', authMiddleware, requireRole('pi'), asyncHandler(async (req: Request, res: Response) => {
-  const { title, description, requiredSkills, minGpa, isFunded, compensationType, deadline, timeCommitment, qualifications } = req.body;
+  const { title, description, requiredSkills, minGpa, isFunded, compensationType, deadline, timeCommitment, qualifications, applicationQuestions } = req.body;
   if (!title) {
     return res.status(400).json({ error: 'Title is required' });
   }
@@ -40,11 +42,12 @@ router.post('/', authMiddleware, requireRole('pi'), asyncHandler(async (req: Req
     return res.status(404).json({ error: 'PI profile not found' });
   }
   const compType = compensationType ?? (isFunded ? 'paid' : 'unpaid');
+  const aqJson = JSON.stringify(Array.isArray(applicationQuestions) ? applicationQuestions : []);
 
   const result = await pool.query(
     `INSERT INTO research_positions
-       (pi_id, title, description, required_skills, min_gpa, compensation_type, deadline, time_commitment, qualifications)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       (pi_id, title, description, required_skills, min_gpa, compensation_type, deadline, time_commitment, qualifications, application_questions)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
      RETURNING *`,
     [
       pi.id,
@@ -56,6 +59,7 @@ router.post('/', authMiddleware, requireRole('pi'), asyncHandler(async (req: Req
       deadline ?? null,
       timeCommitment ?? null,
       qualifications ?? null,
+      aqJson,
     ]
   );
   return res.status(201).json(rowToPosition(result.rows[0]));
@@ -199,7 +203,7 @@ router.get('/:id', asyncHandler(async (req: Request, res: Response) => {
 // PUT /api/positions/:id - update (owner only)
 router.put('/:id', authMiddleware, requireRole('pi'), asyncHandler(async (req: Request, res: Response) => {
   const { id } = req.params;
-  const { title, description, requiredSkills, minGpa, isFunded, compensationType, isOpen, status, deadline, timeCommitment, qualifications } = req.body;
+  const { title, description, requiredSkills, minGpa, isFunded, compensationType, isOpen, status, deadline, timeCommitment, qualifications, applicationQuestions } = req.body;
   const piResult = await pool.query('SELECT id FROM pi_profiles WHERE user_id = $1', [req.userId]);
   const pi = piResult.rows[0];
   if (!pi) {
@@ -220,6 +224,11 @@ router.put('/:id', authMiddleware, requireRole('pi'), asyncHandler(async (req: R
     resolvedCompType = isFunded ? 'paid' : 'unpaid';
   }
 
+  const aqParam =
+    applicationQuestions !== undefined
+      ? JSON.stringify(Array.isArray(applicationQuestions) ? applicationQuestions : [])
+      : null;
+
   const result = await pool.query(
     `UPDATE research_positions SET
        title             = COALESCE($1, title),
@@ -230,8 +239,9 @@ router.put('/:id', authMiddleware, requireRole('pi'), asyncHandler(async (req: R
        status            = COALESCE($6::position_status, status),
        deadline          = COALESCE($7, deadline),
        time_commitment   = COALESCE($8, time_commitment),
-       qualifications    = COALESCE($9, qualifications)
-     WHERE id = $10 AND pi_id = $11
+       qualifications    = COALESCE($9, qualifications),
+       application_questions = COALESCE($10::jsonb, application_questions)
+     WHERE id = $11 AND pi_id = $12
      RETURNING *`,
     [
       title ?? null,
@@ -243,6 +253,7 @@ router.put('/:id', authMiddleware, requireRole('pi'), asyncHandler(async (req: R
       deadline ?? null,
       timeCommitment ?? null,
       qualifications ?? null,
+      aqParam,
       id,
       pi.id,
     ]


### PR DESCRIPTION
Adds StudentSettings and routes /student/settings separately from profile. Position detail shows submitted application as view-only. PIs define text/number/dropdown/multiple-choice questions on positions; answers stored on applications. Schema migration 006 and validate answers on apply. Migrate script tracks schema_migrations and supports --skip-until for existing DBs.

## Summary

<!-- What does this PR do? Briefly describe the changes. -->

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI/CD / infrastructure

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] All CI checks pass (typecheck, lint, build)
- [ ] Tests added or updated for new functionality
- [ ] No secrets or `.env` files committed
- [ ] PR title follows `[PBI-XX] short description` format

## Screenshots (if UI changes)

<!-- Add screenshots or recordings here -->
