### PR TITLE
﻿Implement position close flow with applicant notifications

### DIFF
--- a/POSITION_CLOSE_IMPLEMENTATION.md
+++ b/POSITION_CLOSE_IMPLEMENTATION.md
@@ -1,0 +1,61 @@
+# Position Close Feature - Implementation Summary
+
+## What Was Implemented
+
+### 1. Email Notifications
+**File:** `server/src/lib/email.ts`
+- Added `sendPositionClosedEmail()` function
+- Sends email to affected students when position closes
+- Includes position title, lab name, and withdrawal notice
+- Falls back gracefully if SMTP not configured
+
+### 2. Enhanced Close Endpoint
+**File:** `server/src/routes/positions.ts`
+- `DELETE /api/positions/:id` now:
+  1. Fetches position title and lab name for email
+  2. Updates position status to 'closed'
+  3. Queries all pending/reviewing applicants with their email
+  4. Marks their applications as 'withdrawn'
+  5. Sends individual emails to each affected student
+  6. Logs notification count
+- All operations wrapped in transaction (ROLLBACK on failure)
+
+### 3. Search Results Filter (Already Working)
+**File:** `server/src/routes/positions.ts`
+- `GET /api/positions` (line 75): filters `WHERE rp.status = 'open'`
+- `GET /api/positions/recommended` (line 150): filters `WHERE rp.status = 'open'`
+- Closed positions are automatically excluded from browse and recommendations
+
+## How It Works
+
+**PI closes position:**
+1. PI clicks "Close Position" in dashboard or position edit page
+2. Frontend calls `DELETE /api/positions/:id`
+3. Server:
+   - Sets position status to 'closed'
+   - Marks pending/reviewing applications as 'withdrawn'
+   - Sends email to each affected student
+4. Position removed from student search results immediately
+
+**Students see:**
+- Position disappears from browse/search
+- Application status changes to "withdrawn"
+- Email notification with position details
+
+## Configuration Required
+
+Add to `.env` (optional, emails skip silently if missing):
+```
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-smtp-user
+SMTP_PASS=your-smtp-password
+FROM_EMAIL=noreply@researchhub.ufl.edu
+```
+
+## Testing Notes
+
+- Email delivery depends on SMTP config (gracefully skips if not set)
+- Errors in email sending don't block the close operation
+- Only pending/reviewing applications are notified (accepted/rejected unchanged)
+- Transaction ensures atomicity (all-or-nothing update)

--- a/server/.env.email.example
+++ b/server/.env.email.example
@@ -1,0 +1,24 @@
+# Email Configuration (Optional)
+# If not configured, email notifications will be skipped silently
+# Position close will still work, students just won't receive emails
+
+# Example with Gmail:
+# SMTP_HOST=smtp.gmail.com
+# SMTP_PORT=587
+# SMTP_USER=your-email@gmail.com
+# SMTP_PASS=your-app-password
+# FROM_EMAIL=noreply@researchhub.ufl.edu
+
+# Example with SendGrid:
+# SMTP_HOST=smtp.sendgrid.net
+# SMTP_PORT=587
+# SMTP_USER=apikey
+# SMTP_PASS=your-sendgrid-api-key
+# FROM_EMAIL=noreply@researchhub.ufl.edu
+
+# Example with AWS SES:
+# SMTP_HOST=email-smtp.us-east-1.amazonaws.com
+# SMTP_PORT=587
+# SMTP_USER=your-ses-smtp-username
+# SMTP_PASS=your-ses-smtp-password
+# FROM_EMAIL=noreply@researchhub.ufl.edu

--- a/server/src/lib/email.ts
+++ b/server/src/lib/email.ts
@@ -35,3 +35,33 @@ export async function sendWelcomeEmail(toEmail: string, firstName: string) {
     `,
   });
 }
+
+export async function sendPositionClosedEmail(
+  toEmail: string,
+  firstName: string,
+  positionTitle: string,
+  labName: string | null
+) {
+  const transport = createTransport();
+  if (!transport) {
+    console.log(`[email] SMTP not configured — skipping position closed email to ${toEmail}`);
+    return;
+  }
+  const labInfo = labName ? ` from ${labName}` : '';
+  await transport.sendMail({
+    from: `"ResearchHub" <${config.fromEmail}>`,
+    to: toEmail,
+    subject: `Position closed: ${positionTitle}`,
+    text: `Hi ${firstName},\n\nThe position "${positionTitle}"${labInfo} has been closed and is no longer accepting applications.\n\nYour application status has been updated to withdrawn. You can continue browsing other open positions on ResearchHub.\n\nBest,\nThe ResearchHub Team`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
+        <h2 style="color: #001A3E;">Position Closed</h2>
+        <p>Hi ${firstName},</p>
+        <p>The position <strong>"${positionTitle}"</strong>${labInfo} has been closed and is no longer accepting applications.</p>
+        <p>Your application status has been updated to <strong>withdrawn</strong>. You can continue browsing other open positions on ResearchHub.</p>
+        <br/>
+        <p style="color: #555;">The ResearchHub Team</p>
+      </div>
+    `,
+  });
+}

--- a/server/src/routes/positions.ts
+++ b/server/src/routes/positions.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import pool from '../db/pool.js';
 import { authMiddleware, requireRole } from '../middleware/auth.js';
 import { asyncHandler } from '../lib/asyncHandler.js';
+import { sendPositionClosedEmail } from '../lib/email.js';
 
 const router = Router();
 
@@ -276,20 +277,59 @@ router.delete('/:id', authMiddleware, requireRole('pi'), asyncHandler(async (req
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-    const result = await client.query(
-      `UPDATE research_positions SET status = 'closed' WHERE id = $1 AND pi_id = $2 RETURNING id`,
+    
+    const posResult = await client.query(
+      `SELECT rp.title, pp.lab_name
+       FROM research_positions rp
+       JOIN pi_profiles pp ON pp.id = rp.pi_id
+       WHERE rp.id = $1 AND rp.pi_id = $2`,
       [id, pi.id]
     );
-    if (result.rows.length === 0) {
+    if (posResult.rows.length === 0) {
       await client.query('ROLLBACK');
       return res.status(404).json({ error: 'Position not found or access denied' });
     }
+    const { title: positionTitle, lab_name: labName } = posResult.rows[0];
+
+    const updatePos = await client.query(
+      `UPDATE research_positions SET status = 'closed' WHERE id = $1 AND pi_id = $2 RETURNING id`,
+      [id, pi.id]
+    );
+    if (updatePos.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'Position not found or access denied' });
+    }
+
+    const affectedApps = await client.query(
+      `SELECT a.id, u.email, u.first_name
+       FROM applications a
+       JOIN student_profiles sp ON sp.id = a.student_id
+       JOIN users u ON u.id = sp.user_id
+       WHERE a.position_id = $1 AND a.status IN ('pending', 'reviewing')`,
+      [id]
+    );
+
     await client.query(
       `UPDATE applications SET status = 'withdrawn'
        WHERE position_id = $1 AND status IN ('pending', 'reviewing')`,
       [id]
     );
     await client.query('COMMIT');
+
+    for (const row of affectedApps.rows) {
+      sendPositionClosedEmail(
+        row.email,
+        row.first_name || 'Student',
+        positionTitle,
+        labName
+      ).catch((err) => {
+        console.error(`[email] Failed to send position closed email to ${row.email}:`, err);
+      });
+    }
+
+    console.log(
+      `[positions] Position ${id} closed. ${affectedApps.rows.length} applicant(s) notified.`
+    );
   } catch (err) {
     await client.query('ROLLBACK');
     throw err;


### PR DESCRIPTION
Add email notification system for position closures. When PI closes a position, all pending/reviewing applicants receive email notification and applications are marked withdrawn. Position automatically removed from search results. Email delivery optional (graceful fallback if SMTP not configured). Transaction-wrapped for atomicity.

## Summary

<!-- What does this PR do? Briefly describe the changes. -->

## Related Issue

Closes #18 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI/CD / infrastructure

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] All CI checks pass (typecheck, lint, build)
- [ ] Tests added or updated for new functionality
- [ ] No secrets or `.env` files committed
- [ ] PR title follows `[PBI-XX] short description` format

## Screenshots (if UI changes)

<!-- Add screenshots or recordings here -->
