### PR TITLE
Add external links to student profile

### DIFF
--- a/client/src/components/ProfileLinksDisplay.tsx
+++ b/client/src/components/ProfileLinksDisplay.tsx
@@ -1,0 +1,43 @@
+import { ExternalLink, Github, Linkedin, Globe } from 'lucide-react';
+import type { ProfileLink } from '../types';
+import './profile-links-display.css';
+
+interface ProfileLinksDisplayProps {
+  links: ProfileLink[];
+}
+
+function getLinkIcon(label: string) {
+  const lower = label.toLowerCase();
+  if (lower.includes('github')) return <Github size={16} />;
+  if (lower.includes('linkedin')) return <Linkedin size={16} />;
+  if (lower.includes('website') || lower.includes('portfolio') || lower.includes('personal')) {
+    return <Globe size={16} />;
+  }
+  return <ExternalLink size={16} />;
+}
+
+export function ProfileLinksDisplay({ links }: ProfileLinksDisplayProps) {
+  if (!links || links.length === 0) return null;
+
+  return (
+    <div className="profile-links-display">
+      <h3>Links</h3>
+      <ul className="links-list">
+        {links.map((link) => (
+          <li key={link.id}>
+            <a
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="profile-link-item"
+            >
+              {getLinkIcon(link.label)}
+              <span className="link-label">{link.label}</span>
+              <ExternalLink size={14} className="external-icon" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/ProfileLinksEditor.tsx
+++ b/client/src/components/ProfileLinksEditor.tsx
@@ -1,0 +1,85 @@
+import { Plus, X, Link as LinkIcon } from 'lucide-react';
+import type { ProfileLink } from '../types';
+import './profile-links-editor.css';
+
+interface ProfileLinksEditorProps {
+  links: ProfileLink[];
+  onChange: (links: ProfileLink[]) => void;
+}
+
+export function ProfileLinksEditor({ links, onChange }: ProfileLinksEditorProps) {
+  const addLink = () => {
+    if (links.length >= 5) return;
+    const newLink: ProfileLink = {
+      id: crypto.randomUUID(),
+      label: '',
+      url: '',
+    };
+    onChange([...links, newLink]);
+  };
+
+  const removeLink = (id: string) => {
+    onChange(links.filter((link) => link.id !== id));
+  };
+
+  const updateLink = (id: string, field: 'label' | 'url', value: string) => {
+    onChange(
+      links.map((link) =>
+        link.id === id ? { ...link, [field]: value } : link
+      )
+    );
+  };
+
+  return (
+    <div className="profile-links-editor">
+      <div className="profile-links-header">
+        <label>External Links</label>
+        <button
+          type="button"
+          onClick={addLink}
+          disabled={links.length >= 5}
+          className="add-link-btn"
+        >
+          <Plus size={16} /> Add Link
+        </button>
+      </div>
+      {links.length === 0 && (
+        <p className="no-links-hint">
+          Add links to your LinkedIn, portfolio, GitHub, or personal website so PIs can learn more about your work.
+        </p>
+      )}
+      <div className="links-list">
+        {links.map((link) => (
+          <div key={link.id} className="link-editor-item">
+            <LinkIcon size={16} className="link-icon" />
+            <input
+              type="text"
+              placeholder="Label (e.g., LinkedIn)"
+              value={link.label}
+              onChange={(e) => updateLink(link.id, 'label', e.target.value)}
+              className="link-label-input"
+            />
+            <input
+              type="url"
+              placeholder="https://..."
+              value={link.url}
+              onChange={(e) => updateLink(link.id, 'url', e.target.value)}
+              className="link-url-input"
+            />
+            <button
+              type="button"
+              onClick={() => removeLink(link.id)}
+              className="remove-link-btn"
+              aria-label="Remove link"
+            >
+              <X size={16} />
+            </button>
+          </div>
+        ))}
+      </div>
+      {links.length > 0 && links.length < 5 && (
+        <p className="link-limit-hint">You can add up to {5 - links.length} more link(s).</p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/profile-links-display.css
+++ b/client/src/components/profile-links-display.css
@@ -1,0 +1,47 @@
+.profile-links-display {
+  margin-top: 1.5rem;
+}
+
+.profile-links-display h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 0.75rem;
+}
+
+.profile-links-display .links-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile-link-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  background: #f9f9f9;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  text-decoration: none;
+  color: #0066cc;
+  font-size: 0.9rem;
+  transition: all 0.2s;
+}
+
+.profile-link-item:hover {
+  background: #f0f0f0;
+  border-color: #0066cc;
+  color: #004499;
+}
+
+.profile-link-item .link-label {
+  flex: 1;
+}
+
+.profile-link-item .external-icon {
+  color: #888;
+}

--- a/client/src/components/profile-links-editor.css
+++ b/client/src/components/profile-links-editor.css
@@ -1,0 +1,104 @@
+.profile-links-editor {
+  margin-top: 1.5rem;
+}
+
+.profile-links-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.profile-links-header label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.add-link-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  background: #fff;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #555;
+  transition: all 0.2s;
+}
+
+.add-link-btn:hover:not(:disabled) {
+  background: #f7f7f7;
+  border-color: #aaa;
+}
+
+.add-link-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.no-links-hint {
+  font-size: 0.85rem;
+  color: #777;
+  margin: 0.5rem 0;
+}
+
+.links-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.link-editor-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: #fafafa;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+}
+
+.link-icon {
+  color: #888;
+  flex-shrink: 0;
+}
+
+.link-label-input {
+  width: 150px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+}
+
+.link-url-input {
+  flex: 1;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 4px;
+}
+
+.remove-link-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #d44;
+  padding: 0.25rem;
+  border-radius: 3px;
+  transition: background 0.2s;
+}
+
+.remove-link-btn:hover {
+  background: #fdd;
+}
+
+.link-limit-hint {
+  font-size: 0.8rem;
+  color: #777;
+  margin-top: 0.5rem;
+}

--- a/client/src/pages/pi/StudentDetail.tsx
+++ b/client/src/pages/pi/StudentDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { Navbar } from '../../components/Navbar';
+import { ProfileLinksDisplay } from '../../components/ProfileLinksDisplay';
 import { api } from '../../lib/api';
 import type { AcademicLevel, StudentProfile } from '../../types';
 import './student-detail-pi.css';
@@ -170,6 +171,8 @@ export function StudentDetail() {
                 </div>
               ) : null}
             </section>
+
+            <ProfileLinksDisplay links={student.profileLinks || []} />
           </div>
         </div>
       </div>

--- a/client/src/pages/student/StudentProfile.tsx
+++ b/client/src/pages/student/StudentProfile.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Navbar } from '../../components/Navbar';
+import { ProfileLinksEditor } from '../../components/ProfileLinksEditor';
 import { api, getAuthToken } from '../../lib/api';
-import type { AcademicLevel } from '../../types';
+import type { AcademicLevel, ProfileLink } from '../../types';
 
 const YEAR_LEVELS: AcademicLevel[] = ['freshman', 'sophomore', 'junior', 'senior', 'grad', 'masters', 'phd', 'postdoc'];
 
@@ -19,6 +20,7 @@ export function StudentProfile() {
     bio: '',
     resumeUrl: '',
     yearLevel: '' as AcademicLevel | '',
+    profileLinks: [] as ProfileLink[],
   });
 
   useEffect(() => {
@@ -33,6 +35,7 @@ export function StudentProfile() {
           bio: p.bio || '',
           resumeUrl: p.resumeUrl || '',
           yearLevel: p.yearLevel || '',
+          profileLinks: p.profileLinks || [],
         });
       })
       .catch(() => setError('Failed to load profile'))
@@ -56,6 +59,7 @@ export function StudentProfile() {
         bio: form.bio || null,
         resumeUrl: form.resumeUrl || null,
         yearLevel: form.yearLevel || null,
+        profileLinks: form.profileLinks,
       });
     } catch (err: unknown) {
       setError((err as { message?: string })?.message || 'Failed to save');
@@ -247,6 +251,10 @@ export function StudentProfile() {
               <p className="mt-1 text-sm text-red-600">{uploadError}</p>
             )}
           </div>
+          <ProfileLinksEditor
+            links={form.profileLinks}
+            onChange={(links) => setForm((f) => ({ ...f, profileLinks: links }))}
+          />
           <button
             type="submit"
             disabled={saving}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -2,6 +2,12 @@ import type { ApplicationQuestion, QuestionAnswersMap } from './applicationQuest
 
 export type { ApplicationQuestion, QuestionAnswersMap } from './applicationQuestions';
 
+export interface ProfileLink {
+  id: string;
+  label: string;
+  url: string;
+}
+
 export type UserRole = 'student' | 'pi';
 export type AcademicLevel = 'freshman' | 'sophomore' | 'junior' | 'senior' | 'grad' | 'masters' | 'phd' | 'postdoc';
 /** @deprecated Use AcademicLevel */
@@ -33,6 +39,7 @@ export interface StudentProfile {
   firstName?: string;
   lastName?: string;
   email?: string;
+  profileLinks?: ProfileLink[];
 }
 
 /** PI lab roster: students with an accepted application to one of this PI's positions */

--- a/server/src/lib/profileLinks.ts
+++ b/server/src/lib/profileLinks.ts
@@ -1,54 +1,50 @@
-const MAX_LINKS = 5;
-const LABEL_MAX = 80;
-
-export type ProfileLinkRow = { label: string; url: string };
-
-export function parseProfileLinks(input: unknown): { ok: true; value: ProfileLinkRow[] } | { ok: false; error: string } {
-  if (input === undefined) {
-    return { ok: true, value: [] };
-  }
-  if (input === null) {
-    return { ok: true, value: [] };
-  }
-  if (!Array.isArray(input)) {
-    return { ok: false, error: 'profileLinks must be an array' };
-  }
-  if (input.length > MAX_LINKS) {
-    return { ok: false, error: `At most ${MAX_LINKS} links allowed` };
-  }
-
-  const out: ProfileLinkRow[] = [];
-  for (const item of input) {
-    if (!item || typeof item !== 'object') {
-      return { ok: false, error: 'Each link must be an object with label and url' };
-    }
-    const raw = item as { label?: unknown; url?: unknown };
-    const label = typeof raw.label === 'string' ? raw.label.trim() : '';
-    const urlRaw = typeof raw.url === 'string' ? raw.url.trim() : '';
-    if (!label || !urlRaw) {
-      return { ok: false, error: 'Each link needs a non-empty label and URL' };
-    }
-    if (label.length > LABEL_MAX) {
-      return { ok: false, error: `Link label too long (max ${LABEL_MAX} characters)` };
-    }
-    let u: URL;
-    try {
-      u = new URL(urlRaw);
-    } catch {
-      return { ok: false, error: 'Invalid URL' };
-    }
-    if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-      return { ok: false, error: 'URL must use http:// or https://' };
-    }
-    out.push({ label, url: u.href });
-  }
-  return { ok: true, value: out };
+export interface ProfileLink {
+  id: string;
+  label: string;
+  url: string;
 }
 
-export function rowProfileLinks(row: { profile_links?: unknown }): ProfileLinkRow[] {
-  const raw = row.profile_links;
-  if (raw == null) return [];
+export function isValidUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function parseProfileLinks(raw: unknown): ProfileLink[] {
   if (!Array.isArray(raw)) return [];
-  const parsed = parseProfileLinks(raw);
-  return parsed.ok ? parsed.value : [];
+  const out: ProfileLink[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    const id = typeof o.id === 'string' && o.id.trim() ? o.id.trim() : null;
+    const label = typeof o.label === 'string' ? o.label.trim() : '';
+    const url = typeof o.url === 'string' ? o.url.trim() : '';
+    if (!id || !label || !url) continue;
+    if (!isValidUrl(url)) continue;
+    out.push({ id, label, url });
+  }
+  return out.slice(0, 5);
+}
+
+export function validateProfileLinks(links: unknown): string | null {
+  if (!Array.isArray(links)) return 'Links must be an array';
+  if (links.length > 5) return 'Maximum 5 links allowed';
+  for (let i = 0; i < links.length; i++) {
+    const item = links[i];
+    if (!item || typeof item !== 'object') return `Link ${i + 1} is invalid`;
+    const o = item as Record<string, unknown>;
+    if (typeof o.label !== 'string' || !o.label.trim()) {
+      return `Link ${i + 1} missing label`;
+    }
+    if (typeof o.url !== 'string' || !o.url.trim()) {
+      return `Link ${i + 1} missing URL`;
+    }
+    if (!isValidUrl(o.url)) {
+      return `Link ${i + 1} has invalid URL (must be http:// or https://)`;
+    }
+  }
+  return null;
 }

--- a/server/src/routes/students.ts
+++ b/server/src/routes/students.ts
@@ -5,6 +5,7 @@ import pool from '../db/pool.js';
 import { supabaseAdmin } from '../config/supabase.js';
 import { authMiddleware, requireRole } from '../middleware/auth.js';
 import { asyncHandler } from '../lib/asyncHandler.js';
+import { parseProfileLinks, validateProfileLinks } from '../lib/profileLinks.js';
 
 const router = Router();
 
@@ -68,7 +69,17 @@ router.get('/profile', authMiddleware, requireRole('student'), asyncHandler(asyn
 
 // PUT /api/students/profile - update own profile
 router.put('/profile', authMiddleware, requireRole('student'), asyncHandler(async (req: Request, res: Response) => {
-  const { major, gpa, graduationYear, skills, bio, resumeUrl, yearLevel, interests } = req.body;
+  const { major, gpa, graduationYear, skills, bio, resumeUrl, yearLevel, interests, profileLinks } = req.body;
+  
+  if (profileLinks !== undefined) {
+    const errMsg = validateProfileLinks(profileLinks);
+    if (errMsg) {
+      return res.status(400).json({ error: errMsg });
+    }
+  }
+
+  const linksJson = profileLinks !== undefined ? JSON.stringify(parseProfileLinks(profileLinks)) : null;
+
   const result = await pool.query(
     `UPDATE student_profiles SET
        major           = COALESCE($1, major),
@@ -79,8 +90,9 @@ router.put('/profile', authMiddleware, requireRole('student'), asyncHandler(asyn
        resume_url      = COALESCE($6, resume_url),
        academic_level  = COALESCE($7, academic_level),
        interests       = COALESCE($8, interests),
+       profile_links   = COALESCE($9::jsonb, profile_links),
        updated_at      = NOW()
-     WHERE user_id = $9
+     WHERE user_id = $10
      RETURNING *`,
     [
       major ?? null,
@@ -91,6 +103,7 @@ router.put('/profile', authMiddleware, requireRole('student'), asyncHandler(asyn
       resumeUrl ?? null,
       yearLevel ?? null,
       interests ?? null,
+      linksJson,
       req.userId,
     ]
   );
@@ -109,6 +122,7 @@ router.put('/profile', authMiddleware, requireRole('student'), asyncHandler(asyn
     resumeUrl: row.resume_url,
     yearLevel: row.academic_level,
     interests: row.interests || [],
+    profileLinks: parseProfileLinks(row.profile_links),
   });
 }));
 
@@ -166,6 +180,7 @@ router.get('/', authMiddleware, requireRole('pi'), asyncHandler(async (req: Requ
       firstName: row.first_name,
       lastName: row.last_name,
       email: row.email,
+      profileLinks: parseProfileLinks(row.profile_links),
     }))
   );
 }));
@@ -198,6 +213,7 @@ router.get('/:id', authMiddleware, requireRole('pi'), asyncHandler(async (req: R
     firstName: row.first_name,
     lastName: row.last_name,
     email: row.email,
+    profileLinks: parseProfileLinks(row.profile_links),
   });
 }));
 


### PR DESCRIPTION
Implements PBI-34: External Links on Student Profile

New Features:
- Students can add up to 5 external links with labels and URLs
- Links validated server-side (must be http/https)
- Profile links displayed on student profile with platform-specific icons
- Links visible to PIs on student detail page

Technical Changes:
- Added profile_links JSONB column to student_profiles table (migration 004)
- Created ProfileLinksEditor component with add/remove/edit functionality
- Created ProfileLinksDisplay component with icons for LinkedIn, GitHub, etc.
- Updated student profile API to accept and validate profile links
- Updated StudentProfile page with links editor
- Updated PI StudentDetail page to display clickable links

Validation:
- Maximum 5 links enforced
- URL validation ensures http:// or https:// protocol
- Empty labels or URLs rejected
- Links normalized and sanitized before storage

## Summary

<!-- What does this PR do? Briefly describe the changes. -->

## Related Issue

Closes #48 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI/CD / infrastructure

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] All CI checks pass (typecheck, lint, build)
- [ ] Tests added or updated for new functionality
- [ ] No secrets or `.env` files committed
- [ ] PR title follows `[PBI-XX] short description` format

## Screenshots (if UI changes)

<!-- Add screenshots or recordings here -->
