### PR TITLE
Add student notification preferences API and Settings UI

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,9 @@
       "name": "research-hub-client",
       "version": "1.0.0",
       "dependencies": {
+        "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@react-oauth/google": "^0.13.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -76,6 +78,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -806,6 +809,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -821,6 +830,67 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -828,6 +898,161 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1289,7 +1514,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -1440,6 +1665,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1892,6 +2118,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -2166,6 +2393,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2335,6 +2563,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2347,6 +2576,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2702,6 +2932,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2793,6 +3024,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@react-oauth/google": "^0.13.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/client/src/components/ui/label.tsx
+++ b/client/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { forwardRef } from 'react';
+import { cn } from '../../lib/utils';
+
+export const Label = forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;

--- a/client/src/components/ui/switch.tsx
+++ b/client/src/components/ui/switch.tsx
@@ -1,0 +1,28 @@
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import { forwardRef } from 'react';
+import { cn } from '../../lib/utils';
+
+export const Switch = forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    ref={ref}
+    className={cn(
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent',
+      'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white',
+      'disabled:cursor-not-allowed disabled:opacity-50',
+      'data-[state=checked]:bg-teal-600 data-[state=unchecked]:bg-slate-200',
+      className
+    )}
+    {...props}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform',
+        'data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0'
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -57,6 +57,12 @@ export const api = {
     getProfile: () => request<StudentProfile>('/students/profile'),
     updateProfile: (body: Partial<StudentProfile>) =>
       request<StudentProfile>('/students/profile', { method: 'PUT', body: JSON.stringify(body) }),
+    getNotificationPreferences: () => request<NotificationPreferences>('/students/notification-preferences'),
+    updateNotificationPreferences: (body: Partial<NotificationPreferences>) =>
+      request<NotificationPreferences>('/students/notification-preferences', {
+        method: 'PUT',
+        body: JSON.stringify(body),
+      }),
     list: (params?: { major?: string; minGpa?: number; skills?: string; yearLevel?: string }) => {
       const q = new URLSearchParams(params as Record<string, string>).toString();
       return request<StudentProfile[]>(`/students${q ? `?${q}` : ''}`);

--- a/client/src/pages/student/StudentProfile.tsx
+++ b/client/src/pages/student/StudentProfile.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Navbar } from '../../components/Navbar';
 import { ProfileLinksEditor } from '../../components/ProfileLinksEditor';
 import { api, getAuthToken } from '../../lib/api';
@@ -144,7 +145,14 @@ export function StudentProfile() {
     <div className="min-h-screen">
       <Navbar />
       <div className="max-w-2xl mx-auto px-4 py-8">
-        <h1 className="text-2xl font-bold text-inherit mb-6">Edit Profile</h1>
+        <h1 className="text-2xl font-bold text-inherit mb-2">Edit Profile</h1>
+        <p className="text-sm text-slate-600 mb-6">
+          Manage email notification preferences for research opportunities (departments, keywords, and opt out) on{' '}
+          <Link to="/student/settings" className="text-teal-600 hover:underline font-medium">
+            Settings
+          </Link>
+          .
+        </p>
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
             <div className="p-3 bg-red-50 text-red-700 rounded-lg text-sm">{error}</div>

--- a/client/src/pages/student/StudentSettings.tsx
+++ b/client/src/pages/student/StudentSettings.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Navbar } from '../../components/Navbar';
-import { api } from '../../lib/api';
+import { Label } from '../../components/ui/label';
+import { Switch } from '../../components/ui/switch';
+import { ApiError, api } from '../../lib/api';
 import type { NotificationFrequency, NotificationPreferences } from '../../types';
 
 // ---------------------------------------------------------------------------
@@ -36,6 +38,23 @@ function loadLocalSettings(): LocalSettings {
   }
 }
 
+const MAX_KEYWORDS = 25;
+const MAX_DEPARTMENTS = 15;
+const MAX_TAG_LEN = 80;
+
+const DEPARTMENT_SUGGESTIONS = [
+  'Computer Science',
+  'Psychology',
+  'Biology',
+  'Chemistry',
+  'Physics',
+  'Neuroscience',
+  'Mathematics',
+  'Engineering',
+  'Public Health',
+  'Economics',
+];
+
 // ---------------------------------------------------------------------------
 // Tag-input helper
 // ---------------------------------------------------------------------------
@@ -46,21 +65,37 @@ function TagInput({
   values,
   placeholder,
   onChange,
+  maxItems,
 }: {
   label: string;
   hint: string;
   values: string[];
   placeholder: string;
   onChange: (next: string[]) => void;
+  maxItems: number;
 }) {
   const [draft, setDraft] = useState('');
+  const [hintMsg, setHintMsg] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const atMax = values.length >= maxItems;
 
   const add = () => {
+    setHintMsg(null);
     const trimmed = draft.trim();
-    if (trimmed && !values.includes(trimmed)) {
-      onChange([...values, trimmed]);
+    if (!trimmed) return;
+    if (atMax) {
+      setHintMsg(`You can add at most ${maxItems} entries.`);
+      return;
     }
+    if (trimmed.length > MAX_TAG_LEN) {
+      setHintMsg(`Each entry must be at most ${MAX_TAG_LEN} characters.`);
+      return;
+    }
+    if (values.some((v) => v.toLowerCase() === trimmed.toLowerCase())) {
+      setHintMsg('That value is already added.');
+      return;
+    }
+    onChange([...values, trimmed]);
     setDraft('');
   };
 
@@ -95,6 +130,7 @@ function TagInput({
           className="flex-1 border border-slate-300 rounded-md px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-teal-500"
           placeholder={placeholder}
           value={draft}
+          disabled={atMax}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ',') {
@@ -105,12 +141,17 @@ function TagInput({
         />
         <button
           type="button"
-          className="px-3 py-1.5 text-sm bg-slate-100 hover:bg-slate-200 border border-slate-300 rounded-md"
+          className="px-3 py-1.5 text-sm bg-slate-100 hover:bg-slate-200 border border-slate-300 rounded-md disabled:opacity-50"
           onClick={add}
+          disabled={atMax}
         >
           Add
         </button>
       </div>
+      {hintMsg ? <p className="text-sm text-amber-700">{hintMsg}</p> : null}
+      {atMax ? (
+        <p className="text-xs text-slate-500">Maximum reached. Remove a tag to add another.</p>
+      ) : null}
     </div>
   );
 }
@@ -122,7 +163,6 @@ function TagInput({
 export function StudentSettings() {
   const [local, setLocal] = useState<LocalSettings>(LOCAL_DEFAULTS);
 
-  // Server-backed notification prefs
   const [prefs, setPrefs] = useState<NotificationPreferences>({
     notifyNewPositions: false,
     notificationKeywords: [],
@@ -136,14 +176,15 @@ export function StudentSettings() {
 
   useEffect(() => {
     setLocal(loadLocalSettings());
-    api.notifications
-      .getPreferences()
-      .then((p) => setPrefs(p))
+    api.students
+      .getNotificationPreferences()
+      .then((p) => {
+        setPrefs(p);
+        setPrefsError(null);
+      })
       .catch(() => setPrefsError('Could not load notification preferences.'))
       .finally(() => setPrefsLoading(false));
   }, []);
-
-  // ── Local settings ────────────────────────────────────────────────────────
 
   const persistLocal = (next: LocalSettings) => {
     setLocal(next);
@@ -156,18 +197,28 @@ export function StudentSettings() {
     persistLocal({ ...local, [key]: !local[key] });
   };
 
-  // ── Server prefs ──────────────────────────────────────────────────────────
-
-  const savePrefs = async (next: NotificationPreferences) => {
+  const savePrefs = async (patch: Partial<NotificationPreferences>) => {
+    setPrefsError(null);
+    const next: NotificationPreferences = { ...prefs, ...patch };
+    const prev = prefs;
     setPrefs(next);
     try {
-      const saved = await api.notifications.updatePreferences(next);
+      const saved = await api.students.updateNotificationPreferences(next);
       setPrefs(saved);
       setSavedFlash('Notification preferences saved.');
-    } catch {
-      setPrefsError('Failed to save preferences — please try again.');
+    } catch (err) {
+      setPrefs(prev);
+      const msg =
+        err instanceof ApiError ? err.message : 'Failed to save preferences. Please try again.';
+      setPrefsError(msg);
     }
     window.setTimeout(() => setSavedFlash(null), 2500);
+  };
+
+  const addSuggestedDepartment = (name: string) => {
+    if (prefs.notificationDepartments.length >= MAX_DEPARTMENTS) return;
+    if (prefs.notificationDepartments.some((d) => d.toLowerCase() === name.toLowerCase())) return;
+    void savePrefs({ notificationDepartments: [...prefs.notificationDepartments, name] });
   };
 
   return (
@@ -184,65 +235,66 @@ export function StudentSettings() {
         </p>
 
         {savedFlash ? (
-          <div className="mb-4 p-3 bg-teal-50 text-teal-800 rounded-lg text-sm">{savedFlash}</div>
+          <div className="mb-4 p-3 bg-teal-50 text-teal-800 rounded-lg text-sm border border-teal-100" role="status">
+            {savedFlash}
+          </div>
         ) : null}
         {prefsError ? (
-          <div className="mb-4 p-3 bg-red-50 text-red-700 rounded-lg text-sm">{prefsError}</div>
+          <div className="mb-4 p-3 bg-red-50 text-red-700 rounded-lg text-sm border border-red-100" role="alert">
+            {prefsError}
+          </div>
         ) : null}
 
         <section className="space-y-6">
-
-          {/* ── New-position alerts (server-backed) ── */}
           <div>
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">
-              New Position Alerts
-            </h2>
+            <h2 className="text-lg font-semibold text-inherit mb-1">Notification preferences</h2>
+            <p className="text-sm text-slate-600 mb-3">
+              Choose departments and keywords so we only email you about research opportunities you care about. These
+              settings control new position alert emails from ResearchHub.
+            </p>
             <div className="space-y-5 border border-slate-200 rounded-lg p-4 bg-white">
               {prefsLoading ? (
                 <p className="text-sm text-slate-500">Loading…</p>
               ) : (
                 <>
-                  <label className="flex items-start gap-3 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      className="mt-1 rounded border-slate-300"
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1 min-w-0">
+                      <Label htmlFor="research-email-master" className="text-base">
+                        Email notifications for research opportunities
+                      </Label>
+                      <p className="text-sm text-slate-600">
+                        When on, you can receive batched emails when new open positions match your profile, keywords, and
+                        department filters. Turn off to stop all research opportunity alert emails.
+                      </p>
+                    </div>
+                    <Switch
+                      id="research-email-master"
                       checked={prefs.notifyNewPositions}
-                      onChange={() =>
-                        savePrefs({ ...prefs, notifyNewPositions: !prefs.notifyNewPositions })
-                      }
+                      onCheckedChange={(checked) => void savePrefs({ notifyNewPositions: checked })}
+                      aria-label="Enable research opportunity emails"
                     />
-                    <span>
-                      <span className="font-medium text-inherit block">
-                        Email me when new positions are posted
-                      </span>
-                      <span className="text-sm text-slate-600">
-                        Receive an email (at most once per hour) when a new position matches your skills or
-                        GPA on your profile. Custom keyword filters add to that. Department filter, if set,
-                        restricts alerts to only those departments.
-                      </span>
-                    </span>
-                  </label>
+                  </div>
 
-                  {prefs.notifyNewPositions && (
-                    <div className="pl-7 space-y-5 border-t border-slate-100 pt-4">
+                  {prefs.notifyNewPositions ? (
+                    <div className="space-y-5 border-t border-slate-100 pt-4">
                       <div className="space-y-2">
-                        <span className="font-medium text-inherit block">Email frequency</span>
-                        <span className="text-sm text-slate-600 block">
-                          How often you receive notification emails. Batches all new matches into one email.
-                        </span>
+                        <Label className="text-base">Email frequency</Label>
+                        <p className="text-sm text-slate-600">
+                          How often we send a single email that batches new matching positions.
+                        </p>
                         <div className="flex flex-wrap gap-2 mt-1">
                           {(
                             [
                               { value: 'immediately', label: 'Immediately' },
-                              { value: 'hourly',       label: 'Hourly' },
-                              { value: 'daily',        label: 'Daily' },
-                              { value: 'weekly',       label: 'Weekly' },
+                              { value: 'hourly', label: 'Hourly' },
+                              { value: 'daily', label: 'Daily' },
+                              { value: 'weekly', label: 'Weekly' },
                             ] as { value: NotificationFrequency; label: string }[]
                           ).map(({ value, label }) => (
                             <button
                               key={value}
                               type="button"
-                              onClick={() => savePrefs({ ...prefs, notificationFrequency: value })}
+                              onClick={() => void savePrefs({ notificationFrequency: value })}
                               className={`px-4 py-1.5 rounded-full text-sm border transition-colors ${
                                 prefs.notificationFrequency === value
                                   ? 'bg-teal-600 text-white border-teal-600'
@@ -256,35 +308,58 @@ export function StudentSettings() {
                       </div>
 
                       <TagInput
-                        label="Keyword filters (additive)"
-                        hint="Also notify me for positions whose title, description, or research area contains any of these keywords — on top of your skill/GPA matches."
+                        label="Keyword filters"
+                        hint='Notify when a position title, description, PI research areas, or required skills contain any of these phrases (for example "machine learning", "biology", "psychology"). Works together with your profile skills and GPA.'
                         values={prefs.notificationKeywords}
                         placeholder="e.g. machine learning"
-                        onChange={(next) =>
-                          savePrefs({ ...prefs, notificationKeywords: next })
-                        }
+                        maxItems={MAX_KEYWORDS}
+                        onChange={(next) => void savePrefs({ notificationKeywords: next })}
                       />
+
+                      <div className="space-y-2">
+                        <Label className="text-base">Department filters</Label>
+                        <p className="text-sm text-slate-600">
+                          If you add any department, you will only get alerts for positions whose PI department matches
+                          one of them. Leave empty to allow all departments.
+                        </p>
+                        <p className="text-xs text-slate-500">Quick add:</p>
+                        <div className="flex flex-wrap gap-2">
+                          {DEPARTMENT_SUGGESTIONS.map((d) => {
+                            const taken = prefs.notificationDepartments.some(
+                              (x) => x.toLowerCase() === d.toLowerCase()
+                            );
+                            return (
+                              <button
+                                key={d}
+                                type="button"
+                                disabled={taken || prefs.notificationDepartments.length >= MAX_DEPARTMENTS}
+                                onClick={() => addSuggestedDepartment(d)}
+                                className="px-2.5 py-1 text-xs rounded-full border border-slate-200 bg-slate-50 text-slate-700 hover:border-teal-400 hover:bg-teal-50 disabled:opacity-40 disabled:pointer-events-none"
+                              >
+                                {d}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+
                       <TagInput
-                        label="Department filters (exclusive)"
-                        hint="Only receive alerts from these departments. Leave empty to receive alerts from all departments."
+                        label="Your departments"
+                        hint="Add custom department names if they are not listed above."
                         values={prefs.notificationDepartments}
-                        placeholder="e.g. Computer Science"
-                        onChange={(next) =>
-                          savePrefs({ ...prefs, notificationDepartments: next })
-                        }
+                        placeholder="e.g. Cognitive Science"
+                        maxItems={MAX_DEPARTMENTS}
+                        onChange={(next) => void savePrefs({ notificationDepartments: next })}
                       />
                     </div>
-                  )}
+                  ) : null}
                 </>
               )}
             </div>
           </div>
 
-          {/* ── Other notification settings (local-only) ── */}
           <div>
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">
-              Other Notifications
-            </h2>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">Other notifications</h2>
             <div className="space-y-4 border border-slate-200 rounded-lg p-4 bg-white">
               <label className="flex items-start gap-3 cursor-pointer">
                 <input
@@ -296,8 +371,8 @@ export function StudentSettings() {
                 <span>
                   <span className="font-medium text-inherit block">Application status emails</span>
                   <span className="text-sm text-slate-600">
-                    When a lab updates your application (e.g. reviewing, accepted). Email delivery depends on
-                    server configuration.
+                    When a lab updates your application (for example reviewing or accepted). Delivery depends on server
+                    email configuration.
                   </span>
                 </span>
               </label>
@@ -319,9 +394,7 @@ export function StudentSettings() {
           </div>
 
           <div>
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">
-              Miscellaneous
-            </h2>
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">Miscellaneous</h2>
             <div className="border border-slate-200 rounded-lg p-4 bg-white text-sm text-slate-600">
               More preferences (language, accessibility) can be added here as the product grows.
             </div>

--- a/server/src/lib/studentNotificationPreferences.ts
+++ b/server/src/lib/studentNotificationPreferences.ts
@@ -1,0 +1,148 @@
+import pool from '../db/pool.js';
+
+export const VALID_NOTIFICATION_FREQUENCIES = ['immediately', 'hourly', 'daily', 'weekly'] as const;
+export type ValidNotificationFrequency = (typeof VALID_NOTIFICATION_FREQUENCIES)[number];
+
+export interface NotificationPreferencesDTO {
+  notifyNewPositions: boolean;
+  notificationKeywords: string[];
+  notificationDepartments: string[];
+  notificationFrequency: string;
+}
+
+export interface NotificationPreferencesUpdateBody {
+  notifyNewPositions?: boolean;
+  notificationKeywords?: string[];
+  notificationDepartments?: string[];
+  notificationFrequency?: string;
+}
+
+const MAX_KEYWORDS = 25;
+const MAX_DEPARTMENTS = 15;
+const MAX_TAG_LENGTH = 80;
+
+function normalizeStringArray(
+  raw: unknown,
+  maxItems: number,
+  maxLen: number,
+  fieldLabel: string
+): { ok: true; value: string[] } | { ok: false; error: string } {
+  if (!Array.isArray(raw)) {
+    return { ok: false, error: `${fieldLabel} must be an array` };
+  }
+  if (raw.length > maxItems) {
+    return { ok: false, error: `${fieldLabel} cannot exceed ${maxItems} entries` };
+  }
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const item of raw) {
+    if (typeof item !== 'string') {
+      return { ok: false, error: `Each ${fieldLabel} entry must be a string` };
+    }
+    const t = item.trim();
+    if (!t) {
+      return { ok: false, error: `${fieldLabel} entries cannot be empty` };
+    }
+    if (t.length > maxLen) {
+      return { ok: false, error: `${fieldLabel} entries must be at most ${maxLen} characters` };
+    }
+    const key = t.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return { ok: true, value: out };
+}
+
+export function validateNotificationPreferencesUpdate(body: NotificationPreferencesUpdateBody):
+  | { ok: true; keywords: string[] | null; departments: string[] | null }
+  | { ok: false; error: string } {
+  if (
+    body.notificationFrequency !== undefined &&
+    !VALID_NOTIFICATION_FREQUENCIES.includes(body.notificationFrequency as ValidNotificationFrequency)
+  ) {
+    return {
+      ok: false,
+      error: `notificationFrequency must be one of: ${VALID_NOTIFICATION_FREQUENCIES.join(', ')}`,
+    };
+  }
+
+  let keywords: string[] | null = null;
+  let departments: string[] | null = null;
+
+  if (body.notificationKeywords !== undefined) {
+    const r = normalizeStringArray(body.notificationKeywords, MAX_KEYWORDS, MAX_TAG_LENGTH, 'Keywords');
+    if (!r.ok) return r;
+    keywords = r.value;
+  }
+  if (body.notificationDepartments !== undefined) {
+    const r = normalizeStringArray(body.notificationDepartments, MAX_DEPARTMENTS, MAX_TAG_LENGTH, 'Departments');
+    if (!r.ok) return r;
+    departments = r.value;
+  }
+
+  return { ok: true, keywords, departments };
+}
+
+export function rowToNotificationPreferences(row: {
+  notify_new_positions: boolean;
+  notification_keywords: unknown;
+  notification_departments: unknown;
+  notification_frequency: string;
+}): NotificationPreferencesDTO {
+  return {
+    notifyNewPositions: row.notify_new_positions,
+    notificationKeywords: (row.notification_keywords as string[]) ?? [],
+    notificationDepartments: (row.notification_departments as string[]) ?? [],
+    notificationFrequency: row.notification_frequency ?? 'hourly',
+  };
+}
+
+export async function fetchNotificationPreferencesForUser(
+  userId: string
+): Promise<NotificationPreferencesDTO | null> {
+  const result = await pool.query(
+    `SELECT notify_new_positions, notification_keywords, notification_departments, notification_frequency
+     FROM student_profiles WHERE user_id = $1`,
+    [userId]
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  return rowToNotificationPreferences(row);
+}
+
+export async function updateNotificationPreferencesForUser(
+  userId: string,
+  body: NotificationPreferencesUpdateBody
+): Promise<{ ok: true; data: NotificationPreferencesDTO } | { ok: false; error: string; status: number }> {
+  const v = validateNotificationPreferencesUpdate(body);
+  if (!v.ok) {
+    return { ok: false, error: v.error, status: 400 };
+  }
+
+  const kwParam = v.keywords !== null ? v.keywords : null;
+  const deptParam = v.departments !== null ? v.departments : null;
+
+  const result = await pool.query(
+    `UPDATE student_profiles SET
+       notify_new_positions     = COALESCE($1, notify_new_positions),
+       notification_keywords    = COALESCE($2, notification_keywords),
+       notification_departments = COALESCE($3, notification_departments),
+       notification_frequency   = COALESCE($4, notification_frequency),
+       updated_at               = NOW()
+     WHERE user_id = $5
+     RETURNING notify_new_positions, notification_keywords, notification_departments, notification_frequency`,
+    [
+      body.notifyNewPositions ?? null,
+      kwParam,
+      deptParam,
+      body.notificationFrequency ?? null,
+      userId,
+    ]
+  );
+  const row = result.rows[0];
+  if (!row) {
+    return { ok: false, error: 'Profile not found', status: 404 };
+  }
+  return { ok: true, data: rowToNotificationPreferences(row) };
+}

--- a/server/src/routes/notifications.ts
+++ b/server/src/routes/notifications.ts
@@ -8,10 +8,12 @@ import {
   queueNotificationsForPosition,
   processNotificationQueue,
 } from '../lib/notificationQueue.js';
+import {
+  fetchNotificationPreferencesForUser,
+  updateNotificationPreferencesForUser,
+} from '../lib/studentNotificationPreferences.js';
 
 const router = Router();
-
-const VALID_FREQUENCIES = ['immediately', 'hourly', 'daily', 'weekly'];
 
 // GET /api/notifications/preferences — fetch notification prefs (student only)
 router.get(
@@ -19,20 +21,11 @@ router.get(
   authMiddleware,
   requireRole('student'),
   asyncHandler(async (req: Request, res: Response) => {
-    const result = await pool.query(
-      `SELECT notify_new_positions, notification_keywords, notification_departments,
-              notification_frequency
-       FROM student_profiles WHERE user_id = $1`,
-      [req.userId]
-    );
-    const row = result.rows[0];
-    if (!row) return res.status(404).json({ error: 'Profile not found' });
-    return res.json({
-      notifyNewPositions: row.notify_new_positions as boolean,
-      notificationKeywords: (row.notification_keywords as string[]) ?? [],
-      notificationDepartments: (row.notification_departments as string[]) ?? [],
-      notificationFrequency: (row.notification_frequency as string) ?? 'hourly',
-    });
+    const userId = req.userId;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+    const data = await fetchNotificationPreferencesForUser(userId);
+    if (!data) return res.status(404).json({ error: 'Profile not found' });
+    return res.json(data);
   })
 );
 
@@ -42,44 +35,13 @@ router.put(
   authMiddleware,
   requireRole('student'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { notifyNewPositions, notificationKeywords, notificationDepartments, notificationFrequency } =
-      req.body as {
-        notifyNewPositions?: boolean;
-        notificationKeywords?: string[];
-        notificationDepartments?: string[];
-        notificationFrequency?: string;
-      };
-
-    if (notificationFrequency !== undefined && !VALID_FREQUENCIES.includes(notificationFrequency)) {
-      return res.status(400).json({ error: `notificationFrequency must be one of: ${VALID_FREQUENCIES.join(', ')}` });
+    const userId = req.userId;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+    const result = await updateNotificationPreferencesForUser(userId, req.body);
+    if (!result.ok) {
+      return res.status(result.status).json({ error: result.error });
     }
-
-    const result = await pool.query(
-      `UPDATE student_profiles SET
-         notify_new_positions     = COALESCE($1, notify_new_positions),
-         notification_keywords    = COALESCE($2, notification_keywords),
-         notification_departments = COALESCE($3, notification_departments),
-         notification_frequency   = COALESCE($4, notification_frequency),
-         updated_at               = NOW()
-       WHERE user_id = $5
-       RETURNING notify_new_positions, notification_keywords,
-                 notification_departments, notification_frequency`,
-      [
-        notifyNewPositions ?? null,
-        notificationKeywords ?? null,
-        notificationDepartments ?? null,
-        notificationFrequency ?? null,
-        req.userId,
-      ]
-    );
-    const row = result.rows[0];
-    if (!row) return res.status(404).json({ error: 'Profile not found' });
-    return res.json({
-      notifyNewPositions: row.notify_new_positions as boolean,
-      notificationKeywords: (row.notification_keywords as string[]) ?? [],
-      notificationDepartments: (row.notification_departments as string[]) ?? [],
-      notificationFrequency: row.notification_frequency as string,
-    });
+    return res.json(result.data);
   })
 );
 

--- a/server/src/routes/positions.ts
+++ b/server/src/routes/positions.ts
@@ -2,11 +2,8 @@ import { Router, Request, Response } from 'express';
 import pool from '../db/pool.js';
 import { authMiddleware, requireRole } from '../middleware/auth.js';
 import { asyncHandler } from '../lib/asyncHandler.js';
-<<<<<<< HEAD
 import { queueNotificationsForPosition, processNotificationQueue } from '../lib/notificationQueue.js';
-=======
 import { sendPositionClosedEmail } from '../lib/email.js';
->>>>>>> d24b3f0848d959d4867e1d58fce7820dbe321029
 
 const router = Router();
 

--- a/server/src/routes/students.ts
+++ b/server/src/routes/students.ts
@@ -6,6 +6,10 @@ import { supabaseAdmin } from '../config/supabase.js';
 import { authMiddleware, requireRole } from '../middleware/auth.js';
 import { asyncHandler } from '../lib/asyncHandler.js';
 import { parseProfileLinks, validateProfileLinks } from '../lib/profileLinks.js';
+import {
+  fetchNotificationPreferencesForUser,
+  updateNotificationPreferencesForUser,
+} from '../lib/studentNotificationPreferences.js';
 
 const router = Router();
 
@@ -125,6 +129,36 @@ router.put('/profile', authMiddleware, requireRole('student'), asyncHandler(asyn
     profileLinks: parseProfileLinks(row.profile_links),
   });
 }));
+
+// GET /api/students/notification-preferences — research opportunity email prefs (student only)
+router.get(
+  '/notification-preferences',
+  authMiddleware,
+  requireRole('student'),
+  asyncHandler(async (req: Request, res: Response) => {
+    const userId = req.userId;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+    const data = await fetchNotificationPreferencesForUser(userId);
+    if (!data) return res.status(404).json({ error: 'Profile not found' });
+    return res.json(data);
+  })
+);
+
+// PUT /api/students/notification-preferences
+router.put(
+  '/notification-preferences',
+  authMiddleware,
+  requireRole('student'),
+  asyncHandler(async (req: Request, res: Response) => {
+    const userId = req.userId;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+    const result = await updateNotificationPreferencesForUser(userId, req.body);
+    if (!result.ok) {
+      return res.status(result.status).json({ error: result.error });
+    }
+    return res.json(result.data);
+  })
+);
 
 // GET /api/students - list with filters (PI only)
 router.get('/', authMiddleware, requireRole('pi'), asyncHandler(async (req: Request, res: Response) => {


### PR DESCRIPTION
Completes PBI-29 data path: shared studentNotificationPreferences module with validation, used by GET/PUT /api/notifications/preferences and new GET/PUT /api/students/notification-preferences.

Student Settings: Radix Switch and Label, master email toggle, frequency, keyword and department filters with quick-add chips, client and server validation, success and error feedback.

Profile page links to Settings for notification preferences. Resolves stray merge conflict markers in positions.ts imports.

## Summary

<!-- What does this PR do? Briefly describe the changes. -->

## Related Issue

Closes #44 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] CI/CD / infrastructure

## Checklist

- [ ] TypeScript compiles with no errors (`npm run build`)
- [ ] All CI checks pass (typecheck, lint, build)
- [ ] Tests added or updated for new functionality
- [ ] No secrets or `.env` files committed
- [ ] PR title follows `[PBI-XX] short description` format

## Screenshots (if UI changes)

<!-- Add screenshots or recordings here -->
